### PR TITLE
🐛 (#10) 인가코드요청 임시 리다이렉트 URL 삭제

### DIFF
--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -3,7 +3,7 @@ import kakaoLoginBtnImg from '@/shared/assets/images/kakao_login_large_narrow.pn
 const LoginPage = () => {
   const hadleLoginClick = () => {
     //TODO: 인증 URL 받으면 아래의 주소도 수정할 예정입니다.
-    window.location.href = 'https://kauth.kakao.com/oauth/authorize?11';
+    // window.location.href = '';
   };
   return (
     <div className="flex w-screen h-screen justify-center items-center ">


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약

- 인가코드요청 임시 리다이렉트 URL을 삭제했습니다. 

### ✨ 작업 내용

- 인가코드 요청 URL을 아직 받기 전이라 임시 URL을 만들어서 사용하고 있었습니다. 
- 보안상 위험이 있을 수도 있다고 판단했고, 코드의 명료함을 위해 리다이렉트 부분을 삭제했습니다. 
### ❗ 참고 사항(선택)

- [카카오디벨로퍼스 문서> 인가코드 관련 에러 문서](https://developers.kakao.com/docs/latest/ko/kakaologin/trouble-shooting)에 따르면 인가코드요청 URL 에 필수 파라미터를 누락시에 인가코드 관련 에러(KOE207 invalid_request)가 발생한다고 합니다.
- 따라서 파라미터를 잘못 적었더라도 정보가 유출이 될 것 같지는 않지만 혹시 모를 위험과 코드의 명료성을 위해서 코드를 삭제했습니다.

### #️⃣ 연관 이슈

- Close #10