### PR TITLE
✨ 재사용성을 고려한 모달 시스템 구현 PR

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-error-boundary": "^6.0.0",
+    "react-hot-toast": "^2.6.0",
     "react-router": "^7.8.2",
     "react-router-dom": "^7.8.2",
     "tailwind-merge": "^3.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       react-error-boundary:
         specifier: ^6.0.0
         version: 6.0.0(react@19.1.1)
+      react-hot-toast:
+        specifier: ^2.6.0
+        version: 2.6.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       react-router:
         specifier: ^7.8.2
         version: 7.8.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -1943,6 +1946,11 @@ packages:
   globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
 
+  goober@2.1.16:
+    resolution: {integrity: sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==}
+    peerDependencies:
+      csstype: ^3.0.10
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -2430,6 +2438,13 @@ packages:
     resolution: {integrity: sha512-gdlJjD7NWr0IfkPlaREN2d9uUZUlksrfOx7SX62VRerwXbMY6ftGCIZua1VG1aXFNOimhISsTq+Owp725b9SiA==}
     peerDependencies:
       react: '>=16.13.1'
+
+  react-hot-toast@2.6.0:
+    resolution: {integrity: sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: '>=16'
+      react-dom: '>=16'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -4667,6 +4682,10 @@ snapshots:
 
   globrex@0.1.2: {}
 
+  goober@2.1.16(csstype@3.1.3):
+    dependencies:
+      csstype: 3.1.3
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -5102,6 +5121,13 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.4
       react: 19.1.1
+
+  react-hot-toast@2.6.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+    dependencies:
+      csstype: 3.1.3
+      goober: 2.1.16(csstype@3.1.3)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
 
   react-is@16.13.1: {}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,9 +2,11 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AppRouter } from '@/app/routes/Router';
 import ServerErrorPage from './pages/ServerErrorPage';
 import { ErrorBoundary } from 'react-error-boundary';
+import ModalProvider from '@/shared/components/ui/ModalContainer';
+import { Toaster } from 'react-hot-toast';
 
 const queryClient = new QueryClient();
-// 아래는 에러바운더리 테스트용 코드입니다.  
+// 아래는 에러바운더리 테스트용 코드입니다.
 // const BuggyComponent = () => {
 //   throw new Error('😱 일부러 발생시킨 에러!');
 //   return <div>안보일거야</div>;
@@ -16,8 +18,9 @@ function App() {
       <QueryClientProvider client={queryClient}>
         {/* < AppInitializer/> */}
         {/* <BuggyComponent /> */}
-
+        <ModalProvider />
         <AppRouter />
+        <Toaster position="top-right" reverseOrder={false} />
       </QueryClientProvider>
     </ErrorBoundary>
   );

--- a/src/app/layout/AppLayout.tsx
+++ b/src/app/layout/AppLayout.tsx
@@ -5,11 +5,11 @@ import { Outlet } from 'react-router';
 const AppLayout = () => {
   return (
     <SidebarProvider defaultOpen={false}>
-      <div className=" w-screen h-screen ">
+      <div className="flex w-screen h-screen">
         <AppSidebar />
-       <main className="flex-1 w-screen h-full overflow-auto">
-  <Outlet />
-</main>
+        <main className="flex-1 h-full">
+          <Outlet />
+        </main>
       </div>
     </SidebarProvider>
   );

--- a/src/app/routes/Router.tsx
+++ b/src/app/routes/Router.tsx
@@ -7,6 +7,7 @@ import { createBrowserRouter } from 'react-router';
 import { RouterProvider } from 'react-router-dom';
 import ProtectedRoute from '@/app/routes/ProtectedRoute';
 import ServerErrorPage from '@/pages/ServerErrorPage';
+import ModalTestPage from '@/pages/ModalTestPage';
 
 export const ROUTE_PATH = {
   MAIN: '/',
@@ -14,27 +15,28 @@ export const ROUTE_PATH = {
   PROJECT: '/project/:projectId',
   MYTASK: '/my-task',
   ERROR: '/error',
+  MODAL: '/modal-test',
 };
+
 const PUBLIC_ROUTES = [
   { path: '/', element: <LandingPage /> },
   { path: '/login', element: <LoginPage /> },
   { path: '/error', element: <ServerErrorPage /> },
+  { path: ROUTE_PATH.MODAL, element: <ModalTestPage /> },
 ];
+
 const PROTECTED_ROUTES = [
   { path: '/project/:projectId', element: <ProjectPage /> },
   { path: '/my-task', element: <MyTaskPage /> },
 ];
 
 export const router = createBrowserRouter([
-  { path: ROUTE_PATH.MAIN, element: <LandingPage /> },
-  { path: ROUTE_PATH.LOGIN, element: <LoginPage /> },
-
+  // 공개 라우트
+  ...PUBLIC_ROUTES,
   {
     path: '/',
     element: <AppLayout />,
     children: [
-      // 공개 라우트
-      ...PUBLIC_ROUTES,
       // 보호된 라우트
       ...PROTECTED_ROUTES.map((route) => ({
         ...route,

--- a/src/features/landing/components/HeroSection.tsx
+++ b/src/features/landing/components/HeroSection.tsx
@@ -17,7 +17,8 @@ const HeroSection = () => {
 
   const options = [
     { label: '프로젝트 페이지', click: () => navigate(`/project/${123}`) },
-    { label: '에러 페이지', click: () => navigate('/error') },
+    { label: '에러 페이지', click: () => navigate(ROUTE_PATH.ERROR) },
+    { label: '모달 테스트 페이지', click: () => navigate(ROUTE_PATH.MODAL) },
   ];
 
   return (
@@ -49,13 +50,13 @@ const HeroSection = () => {
               <DropdownMenuTrigger asChild>
                 <Button
                   variant="secondary"
-                  className="bg-gray-300 shadow-sm w-full sm:w-36 h-10 focus:ring-transparent"
+                  className="bg-gray-300 shadow-sm w-full sm:w-40 h-10 focus:ring-transparent"
                 >
                   데모 보기
                 </Button>
               </DropdownMenuTrigger>
 
-              <DropdownMenuContent className="w-full sm:w-36 border-gray-300 mt-1">
+              <DropdownMenuContent className="w-full sm:w-40 border-gray-300 mt-1">
                 {options.map((opt) => (
                   <DropdownMenuItem
                     key={opt.label}

--- a/src/features/project/components/ProjectCreateModalContent.tsx
+++ b/src/features/project/components/ProjectCreateModalContent.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import { Input } from '@/shared/components/shadcn/input';
+import { Button } from '@/shared/components/shadcn/button';
+import { DialogFooter } from '@/shared/components/shadcn/dialog';
+import useModalStore from '@/shared/store/useModalStore';
+
+interface ProjectCreateModalProps {
+  onConfirm: (projectName: string) => Promise<void> | void;
+}
+
+const ProjectCreateModalContent = ({ onConfirm }: ProjectCreateModalProps) => {
+  const [projectName, setProjectName] = useState('');
+  const { closeModal, isLoading, setLoading, backModal } = useModalStore();
+
+  const handleConfirm = async () => {
+    setLoading(true);
+    try {
+      await onConfirm(projectName);
+      closeModal();
+    } catch (error) {
+      console.error('프로젝트 생성 실패 :', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="py-4">
+        <Input
+          id="projectName"
+          value={projectName}
+          placeholder="프로젝트 이름을 입력해주세요."
+          onChange={(e) => setProjectName(e.target.value)}
+          disabled={isLoading}
+          className="border-gray-400 h-10 focus:ring-transparent focus:border-gray-600"
+        />
+      </div>
+      <DialogFooter>
+        <Button
+          onClick={backModal}
+          variant="outline"
+          disabled={isLoading}
+          className="border-gray-400 sm:w-20 hover:bg-gray-200"
+        >
+          취소
+        </Button>
+        <Button
+          onClick={handleConfirm}
+          disabled={!projectName || isLoading}
+          className="bg-boost-blue sm:w-20 hover:bg-boost-blue-pressed cursor-pointer"
+        >
+          생성
+        </Button>
+      </DialogFooter>
+    </>
+  );
+};
+
+export default ProjectCreateModalContent;

--- a/src/features/project/components/ProjectJoinModalContent.tsx
+++ b/src/features/project/components/ProjectJoinModalContent.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import { Input } from '@/shared/components/shadcn/input';
+import { Button } from '@/shared/components/shadcn/button';
+import { DialogFooter } from '@/shared/components/shadcn/dialog';
+import useModalStore from '@/shared/store/useModalStore';
+
+interface ProjectJoinModalProps {
+  onConfirm: (joinCode: string) => Promise<void> | void;
+}
+
+const ProjectJoinModalContent = ({ onConfirm }: ProjectJoinModalProps) => {
+  const [joinCode, setJoinCode] = useState('');
+  const { closeModal, isLoading, setLoading, backModal } = useModalStore();
+
+  const handleConfirm = async () => {
+    setLoading(true);
+    try {
+      await onConfirm(joinCode);
+      closeModal();
+    } catch (error) {
+      console.error('Project creation failed:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="py-4">
+        <Input
+          id="joinCode"
+          value={joinCode}
+          placeholder="참여코드를 입력해주세요."
+          onChange={(e) => setJoinCode(e.target.value)}
+          disabled={isLoading}
+          className="border-gray-400 h-10 focus:ring-transparent focus:border-gray-600"
+        />
+      </div>
+      <DialogFooter>
+        <Button
+          onClick={backModal}
+          variant="outline"
+          disabled={isLoading}
+          className="border-gray-400 sm:w-20 hover:bg-gray-200 cursor-pointer"
+        >
+          취소
+        </Button>
+        <Button
+          onClick={handleConfirm}
+          disabled={!joinCode || isLoading}
+          className="bg-boost-blue sm:w-20 hover:bg-boost-blue-pressed cursor-pointer"
+        >
+          입력
+        </Button>
+      </DialogFooter>
+    </>
+  );
+};
+
+export default ProjectJoinModalContent;

--- a/src/pages/ModalTestPage.tsx
+++ b/src/pages/ModalTestPage.tsx
@@ -1,0 +1,135 @@
+import { Button } from '@/shared/components/shadcn/button';
+import ProjectCreateModalContent from '@/features/project/components/ProjectCreateModalContent';
+import ProjectJoinModalContent from '@/features/project/components/ProjectJoinModalContent';
+import { useModal } from '@/shared/hooks/useModal';
+import { useCreateProjectMutation } from '@/features/project/hooks/useCreateProjectMutation';
+import toast from 'react-hot-toast';
+
+const ModalTestPage = () => {
+  const { showAlert, showConfirm, showCustom, closeModal } = useModal();
+  const createProjectMutation = useCreateProjectMutation();
+
+  return (
+    <div className="h-screen flex gap-4 items-center justify-center">
+      {/* Confirm 모달 */}
+      <Button
+        onClick={() =>
+          showConfirm(
+            { title: '확인 모달', description: '정말 이 작업을 진행하시겠습니까?' },
+            async () => {
+              console.log('확인 클릭');
+              toast.success('작업이 성공적으로 진행되었어요!');
+            },
+            () => console.log('취소 클릭'),
+          )
+        }
+      >
+        confirm
+      </Button>
+
+      {/* Alert 모달 */}
+      <Button
+        onClick={() =>
+          showAlert({ title: '알림 모달', description: '작업이 완료되었습니다.' }, () =>
+            console.log('확인 클릭'),
+          )
+        }
+      >
+        alert
+      </Button>
+
+      {/* Custom 모달 */}
+      <Button
+        onClick={() =>
+          showCustom({
+            title: '커스텀 모달',
+            description: '커스텀 내용 포함 가능',
+            content: (
+              <div className="p-4 bg-gray-100 rounded text-center">
+                여기에 내가 만들고 싶은 내용을 content 컴포넌트로 만들어 추가합니다.
+              </div>
+            ),
+            buttons: [{ text: '닫기', onClick: () => closeModal(), variant: 'primary' }],
+          })
+        }
+      >
+        custom
+      </Button>
+
+      {/* Select 모달 */}
+      <Button
+        onClick={() =>
+          showCustom({
+            title: '선택 모달',
+            description: '두 가지 선택지 중 한 가지를 선택해보세요.',
+            buttons: [
+              {
+                text: '왼쪽 선택지',
+                onClick: () => {
+                  console.log('왼쪽 선택지 클릭됨!');
+                  toast.success('왼쪽 선택지 클릭됨!');
+                },
+              },
+              {
+                text: '오른쪽 선택지',
+                onClick: () => {
+                  console.log('오른쪽 선택지 클릭됨!');
+                  toast.success('오른쪽 선택지 클릭됨!');
+                },
+              },
+            ],
+          })
+        }
+      >
+        Select
+      </Button>
+
+      {/* Select 모달 + Custom 모달 */}
+      <Button
+        onClick={() =>
+          showCustom({
+            title: '프로젝트가 존재하지 않아요!',
+            description: '프로젝트에 참여하거나, 생성해보세요.',
+            buttons: [
+              {
+                text: '프로젝트 생성',
+                onClick: () =>
+                  showCustom({
+                    title: '프로젝트 생성하기',
+                    description: '프로젝트 이름을 입력하면, 새로운 프로젝트를 생성할 수 있어요.',
+                    content: (
+                      <ProjectCreateModalContent
+                        onConfirm={async (projectName) => {
+                          await createProjectMutation.mutateAsync(projectName);
+                          toast.success('프로젝트가 성공적으로 생성되었습니다!');
+                        }}
+                      />
+                    ),
+                  }),
+              },
+              {
+                text: '프로젝트 참여',
+                onClick: () =>
+                  showCustom({
+                    title: '프로젝트 참여하기',
+                    description: '프로젝트 참여 코드를 입력하면, 프로젝트에 참여할 수 있어요.',
+                    content: (
+                      <ProjectJoinModalContent
+                        onConfirm={async () => {
+                          toast.success('프로젝트에 참여했어요!');
+                        }}
+                      />
+                    ),
+                  }),
+              },
+            ],
+          })
+        }
+      >
+        프로젝트 없을 때
+      </Button>
+    </div>
+  );
+};
+
+export default ModalTestPage;

--- a/src/pages/ProjectPage.tsx
+++ b/src/pages/ProjectPage.tsx
@@ -9,7 +9,7 @@ const ProjectPage = () => {
   const { projectId } = useParams<{ projectId: string }>();
 
   return (
-    <div className="flex flex-row h-screen">
+    <div className="flex flex-row min-h-screen overflow-auto">
       <div className="flex-1 flex flex-col">
         <TobTab />
         <Header projectId={Number(projectId)} />

--- a/src/shared/components/shadcn/dialog.tsx
+++ b/src/shared/components/shadcn/dialog.tsx
@@ -1,0 +1,141 @@
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { XIcon } from "lucide-react"
+
+import { cn } from "@/shared/lib/utils"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/src/shared/components/ui/ModalButtons.tsx
+++ b/src/shared/components/ui/ModalButtons.tsx
@@ -1,0 +1,39 @@
+import { Button } from '@/shared/components/shadcn/button';
+import { Loader2 } from 'lucide-react';
+import { DialogFooter } from '@/shared/components/shadcn/dialog';
+import useModalStore from '@/shared/store/useModalStore';
+import type { ModalButton } from '@/shared/types/modalTypes';
+
+interface ModalButtonsProps {
+  buttons: ModalButton[];
+}
+
+export function ModalButtons({ buttons }: ModalButtonsProps) {
+  const { isLoading, setLoading } = useModalStore();
+
+  const handleClick = async (onClick: () => void | Promise<void>) => {
+    setLoading(true);
+
+    try {
+      await onClick();
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <DialogFooter className="flex gap-2 mt-4">
+      {buttons.map((btn) => (
+        <Button
+          key={btn.text}
+          onClick={() => handleClick(btn.onClick)}
+          disabled={btn.disabled || isLoading}
+          className="flex-1"
+        >
+          {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          {btn.text}
+        </Button>
+      ))}
+    </DialogFooter>
+  );
+}

--- a/src/shared/components/ui/ModalContainer.tsx
+++ b/src/shared/components/ui/ModalContainer.tsx
@@ -1,0 +1,33 @@
+import useModalStore from '@/shared/store/useModalStore';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/shared/components/shadcn/dialog';
+import { ModalButtons } from '@/shared/components/ui/ModalButtons';
+
+const ModalContainer = () => {
+  const { stack, closeModal } = useModalStore();
+  const current = stack[stack.length - 1];
+
+  if (!current) return null;
+
+  return (
+    <Dialog open={!!current} onOpenChange={closeModal}>
+      <DialogContent className="sm:max-w-[425px] border-gray-300">
+        <DialogHeader className="mb-0">
+          <DialogTitle>{current.title}</DialogTitle>
+          {current.description && (
+            <DialogDescription className="label2-regular">{current.description}</DialogDescription>
+          )}
+        </DialogHeader>
+        {current.content}
+        {current.buttons && <ModalButtons buttons={current.buttons} />}
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default ModalContainer;

--- a/src/shared/components/ui/ProjectsMenu.tsx
+++ b/src/shared/components/ui/ProjectsMenu.tsx
@@ -5,41 +5,48 @@ import {
   SidebarMenuSubButton,
 } from '@/shared/components/shadcn/sidebar';
 import { Plus } from 'lucide-react';
-import React from 'react';
 import { Link } from 'react-router';
+import useModalStore from '@/shared/store/useModalStore';
+import ProjectCreateModalContent from '@/features/project/components/ProjectCreateModalContent';
+import { useCreateProjectMutation } from '@/features/project/hooks/useCreateProjectMutation';
+import toast from 'react-hot-toast';
+
 interface SidebarMenuItemProps {
   item: SidebarItem;
 }
+
 const ProjectsMenu = ({ item }: SidebarMenuItemProps) => {
-  const [open, setOpen] = React.useState(false);
+  const { openModal } = useModalStore();
+
+  const createProjectMutation = useCreateProjectMutation();
+
+  const handleOpenProjectCreateModal = () => {
+    openModal({
+      type: 'custom',
+      title: '프로젝트 생성하기',
+      description: '프로젝트 이름을 입력하면, 새로운 프로젝트를 생성할 수 있어요.',
+      content: (
+        <ProjectCreateModalContent
+          onConfirm={async (projectName) => {
+            await createProjectMutation.mutateAsync(projectName);
+            toast.success(`프로젝트가 성공적으로 생성되었습니다!`);
+          }}
+        />
+      ),
+    });
+  };
 
   return (
     <>
-      {open && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-          <div className="bg-white rounded-xl shadow-lg p-6 w-[400px]">
-            <h2 className="text-lg font-semibold mb-4">프로젝트 생성</h2>
-            <input
-              type="text"
-              placeholder="프로젝트 이름"
-              className="w-full border rounded-md px-3 py-2 mb-4"
-            />
-            <div className="flex justify-end gap-2">
-              <button onClick={() => setOpen(false)} className="px-4 py-2 rounded-md border">
-                취소
-              </button>
-              <button className="px-4 py-2 rounded-md bg-blue-600 text-white">생성</button>
-            </div>
-          </div>
-        </div>
-      )}
       <SidebarMenuButton>
         {item.icon}
         <span className="flex-shrink-0">{item.title}</span>
 
         <Plus
-          onClick={() => {
-            setOpen(true);
+          onClick={(e) => {
+            e.stopPropagation();
+            e.preventDefault();
+            handleOpenProjectCreateModal();
           }}
           className="ml-auto cursor-pointer"
         />
@@ -54,7 +61,7 @@ const ProjectsMenu = ({ item }: SidebarMenuItemProps) => {
             </SidebarMenuSubButton>
           );
         })}
-      </SidebarMenuSub>
+      </SidebarMenuSub>{' '}
     </>
   );
 };

--- a/src/shared/hooks/useModal.ts
+++ b/src/shared/hooks/useModal.ts
@@ -1,0 +1,80 @@
+import useModalStore from '@/shared/store/useModalStore';
+import type { ModalPayload, ModalButton } from '@/shared/types/modalTypes';
+
+type ButtonAction = () => void | Promise<void>;
+interface CommonModalProps {
+  title: string;
+  description?: string;
+}
+
+export const useModal = () => {
+  const { openModal, closeModal, backModal } = useModalStore();
+
+  const wrapButton = (btn: ModalButton): ModalButton => ({
+    ...btn,
+    onClick: async () => {
+      try {
+        await btn.onClick();
+        closeModal();
+      } catch (err) {
+        console.error('Modal action failed:', err);
+      }
+    },
+  });
+
+  const showAlert = ({ title, description }: CommonModalProps, onConfirm?: ButtonAction) => {
+    openModal({
+      type: 'alert',
+      title,
+      description,
+      buttons: [
+        wrapButton({
+          text: '확인',
+          onClick: async () => {
+            await onConfirm?.();
+          },
+        }),
+      ],
+    });
+  };
+
+  const showConfirm = (
+    { title, description }: CommonModalProps,
+    onConfirm: ButtonAction,
+    onCancel?: ButtonAction,
+  ) => {
+    openModal({
+      type: 'confirm',
+      title,
+      description,
+      buttons: [
+        {
+          text: '취소',
+          variant: 'outline',
+          onClick: async () => {
+            await onCancel?.();
+            closeModal();
+          },
+        },
+        wrapButton({
+          text: '확인',
+          onClick: onConfirm,
+        }),
+      ],
+    });
+  };
+
+  const showCustom = (payload: Omit<ModalPayload, 'type' | 'id'>) => {
+    openModal({ ...payload, type: 'custom' });
+  };
+
+  const showSelect = (payload: Omit<ModalPayload, 'type'>) => {
+    openModal({
+      ...payload,
+      type: 'select',
+      buttons: payload.buttons?.map(wrapButton),
+    });
+  };
+
+  return { showAlert, showConfirm, showCustom, showSelect, closeModal, backModal };
+};

--- a/src/shared/store/useModalStore.ts
+++ b/src/shared/store/useModalStore.ts
@@ -1,0 +1,26 @@
+import { create } from 'zustand';
+import type { ModalPayload } from '@/shared/types/modalTypes';
+
+interface ModalState {
+  stack: ModalPayload[];
+  isLoading: boolean;
+  openModal: (payload: ModalPayload) => void;
+  closeModal: () => void;
+  backModal: () => void;
+  setLoading: (isLoading: boolean) => void;
+}
+
+const useModalStore = create<ModalState>((set) => ({
+  stack: [],
+  isLoading: false,
+  openModal: (payload) => set((state) => ({ stack: [...state.stack, payload] })),
+  closeModal: () => set({ stack: [], isLoading: false }),
+  backModal: () =>
+    set((state) => ({
+      stack: state.stack.length > 1 ? state.stack.slice(0, -1) : [],
+      isLoading: false,
+    })),
+  setLoading: (isLoading) => set({ isLoading }),
+}));
+
+export default useModalStore;

--- a/src/shared/types/modalTypes.ts
+++ b/src/shared/types/modalTypes.ts
@@ -1,0 +1,16 @@
+import type { ReactNode } from 'react';
+
+export type ModalButton = {
+  text: string;
+  onClick: () => void | Promise<void>;
+  variant?: 'default' | 'outline' | 'primary' | 'destructive';
+  disabled?: boolean;
+};
+
+export type ModalPayload = {
+  type: 'confirm' | 'alert' | 'custom' | 'select';
+  title: string;
+  description?: string;
+  content?: ReactNode;
+  buttons?: ModalButton[];
+};


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약

- 재사용성을 고려한 모달 기능을 구현했습니다.

<br/>

### ✨ 작업 내용

- 전역 기반으로 모달 시스템을 구현했습니다.

#### 1. useModalStore
- 전역적으로 모달 상태를 관리하고, 중첩 및 뒤로가기 기능을 위해서 `zustand`를 이용해 모달 상태 관리 스토어를 구현했습니다. (useModalStore)
- 프로젝트 생성/참여 관련하여 모달의 중첩이 있는 경우가 있어서 `stack`으로 모달을 관리하였습니다.

#### 2. useModal
- 모달 호출 로직을 한 곳에 모아 가독성을 높이도록 하였습니다.

#### 3. ModalContainer
- 모달 렌더링을 한 곳에 모아 UI와 상태 로직을 분리하도록 하였습니다.
- stack 기반으로 설계되어 여러 모달이 중첩 가능합니다.
- UI는 shadcn/ui의 `Dialog`를 사용했습니다.

#### 4. ModalButtons
- 모달별 버튼으로 인해 코드가 중복되는 것을 막기 위해 전달 받은 버튼 배열을 기반으로 버튼 UI를 렌더링하도록 구현했습니다.

#### 4. ModalTestPage
- 모달 분리 로직을 구현하긴 했으나 수정사항이 있을 것 같아 다른 페이지에 모달을 연결하지 않은 상태입니다. 
- 금주에 피드백을 받은 후 모달 분리 로직 고정 후, 페이지에 연동하겠습니다.
- 그 전까지 테스트에 사용될 모달 테스트 페이지입니다.
- 각 형태의 모달을 확인할 수 있습니다.
<img width="1919" height="984" alt="image" src="https://github.com/user-attachments/assets/f0f0d798-ef33-4a5b-95a7-5f91082a2e3d" />

<img width="1919" height="988" alt="image" src="https://github.com/user-attachments/assets/5a373f77-985e-47b7-ad79-aaf8dd7fe9bc" />

<img width="1919" height="987" alt="image" src="https://github.com/user-attachments/assets/0e402ca7-efb2-4ad9-88dc-085cf65a18f3" />

-  프로젝트가 존재하지 않을 때 띄워줄 모달을 임시로 구현해보았습니다.
<img width="1918" height="985" alt="image" src="https://github.com/user-attachments/assets/021d0804-4807-47d8-91e1-f2d6d613a3b4" />

<img width="1919" height="986" alt="image" src="https://github.com/user-attachments/assets/18630735-04d0-43f6-a2e2-ea81d1bef313" />

<img width="1919" height="986" alt="image" src="https://github.com/user-attachments/assets/8c025109-a9ec-4081-afc9-e79f8abbd2e0" />
    
- 처리 여부는 react-hot-toast를 이용해 토스트를 띄우도록 해두었습니다.
<img width="1128" height="614" alt="image" src="https://github.com/user-attachments/assets/4171c99f-749c-4f72-b0ee-b0358865de65" />



<br/>

### ❗ 참고 사항 

- ModalContainer는 파일명 상 “컨테이너”지만, 앱 최상단에서 전역 모달 상태를 관리하고 렌더링하기 때문에 실제로는 모달 Provider 역할을 합니다. 그렇기 때문에 App.tsx에서 <ModalProvider>로 사용하면, 전역 모달 상태를 제공하고 어디서든 모달을 호출할 수 있는 컨텍스트처럼 동작합니다. 파일 네이밍은 ModalContainer로 했지만 기능은 Provider 역할임을 강조하기 위해 App에서는 ModalProvider라는 이름으로 임포트/사용했습니다.

- `모달`은 공통으로 사용된다 라는 생각이 들어 shared 폴더에 구현했습니다만, 혹시 task나 project처럼, modal도 features 폴더에 두는 것이 좋을까요? 논의가 필요할 것 같아요!

- 기본적으로 페이지를 가리는 사이드바 UI 오류는 수정했는데, 250% 이상으로 화면 확대시 사이드바가 사라지는 문제는 아직 해결하지 못했습니다.

<br/>

### #️⃣ 연관 이슈

- Close #7, #33, #35
