### PR TITLE
♻️ 3차 코드 리뷰 반영 - modal 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AppRouter } from '@/app/routes/Router';
 import ServerErrorPage from './pages/ServerErrorPage';
 import { ErrorBoundary } from 'react-error-boundary';
-import ModalProvider from '@/shared/components/ui/ModalContainer';
+import ModalRenderer from '@/shared/components/modal/ModalRenderer';
 import { Toaster } from 'react-hot-toast';
 
 const queryClient = new QueryClient();
@@ -18,7 +18,7 @@ function App() {
       <QueryClientProvider client={queryClient}>
         {/* < AppInitializer/> */}
         {/* <BuggyComponent /> */}
-        <ModalProvider />
+        <ModalRenderer />
         <AppRouter />
         <Toaster position="top-right" reverseOrder={false} />
       </QueryClientProvider>

--- a/src/features/project/components/ProjectCreateModalContent.tsx
+++ b/src/features/project/components/ProjectCreateModalContent.tsx
@@ -10,13 +10,14 @@ interface ProjectCreateModalProps {
 
 const ProjectCreateModalContent = ({ onConfirm }: ProjectCreateModalProps) => {
   const [projectName, setProjectName] = useState('');
-  const { closeModal, isLoading, setLoading, backModal } = useModalStore();
+  const { resetModal, setLoading, backModal, stack } = useModalStore();
+  const isLoading = stack[stack.length - 1]?.isLoading ?? false;
 
   const handleConfirm = async () => {
     setLoading(true);
     try {
       await onConfirm(projectName);
-      closeModal();
+      resetModal();
     } catch (error) {
       console.error('프로젝트 생성 실패 :', error);
     } finally {

--- a/src/features/project/components/ProjectJoinModalContent.tsx
+++ b/src/features/project/components/ProjectJoinModalContent.tsx
@@ -10,15 +10,16 @@ interface ProjectJoinModalProps {
 
 const ProjectJoinModalContent = ({ onConfirm }: ProjectJoinModalProps) => {
   const [joinCode, setJoinCode] = useState('');
-  const { closeModal, isLoading, setLoading, backModal } = useModalStore();
+  const { resetModal, setLoading, backModal, stack } = useModalStore();
+  const isLoading = stack[stack.length - 1]?.isLoading ?? false;
 
   const handleConfirm = async () => {
     setLoading(true);
     try {
       await onConfirm(joinCode);
-      closeModal();
+      resetModal();
     } catch (error) {
-      console.error('Project creation failed:', error);
+      console.error('프로젝트 참여 실패 :', error);
     } finally {
       setLoading(false);
     }

--- a/src/pages/ModalTestPage.tsx
+++ b/src/pages/ModalTestPage.tsx
@@ -6,7 +6,7 @@ import { useCreateProjectMutation } from '@/features/project/hooks/useCreateProj
 import toast from 'react-hot-toast';
 
 const ModalTestPage = () => {
-  const { showAlert, showConfirm, showCustom, closeModal } = useModal();
+  const { showAlert, showConfirm, showCustom, resetModal } = useModal();
   const createProjectMutation = useCreateProjectMutation();
 
   return (
@@ -49,7 +49,7 @@ const ModalTestPage = () => {
                 여기에 내가 만들고 싶은 내용을 content 컴포넌트로 만들어 추가합니다.
               </div>
             ),
-            buttons: [{ text: '닫기', onClick: () => closeModal(), variant: 'primary' }],
+            buttons: [{ text: '닫기', onClick: () => resetModal(), variant: 'primary' }],
           })
         }
       >

--- a/src/shared/components/modal/ModalButtons.tsx
+++ b/src/shared/components/modal/ModalButtons.tsx
@@ -9,7 +9,8 @@ interface ModalButtonsProps {
 }
 
 export function ModalButtons({ buttons }: ModalButtonsProps) {
-  const { isLoading, setLoading } = useModalStore();
+  const { setLoading, stack } = useModalStore();
+  const isLoading = stack[stack.length - 1]?.isLoading ?? false;
 
   const handleClick = async (onClick: () => void | Promise<void>) => {
     setLoading(true);

--- a/src/shared/components/modal/ModalRenderer.tsx
+++ b/src/shared/components/modal/ModalRenderer.tsx
@@ -6,16 +6,15 @@ import {
   DialogTitle,
   DialogDescription,
 } from '@/shared/components/shadcn/dialog';
-import { ModalButtons } from '@/shared/components/ui/ModalButtons';
+import { ModalButtons } from '@/shared/components/modal/ModalButtons';
 
-const ModalContainer = () => {
-  const { stack, closeModal } = useModalStore();
+const ModalRenderer = () => {
+  const { stack, resetModal } = useModalStore();
   const current = stack[stack.length - 1];
-
   if (!current) return null;
 
   return (
-    <Dialog open={!!current} onOpenChange={closeModal}>
+    <Dialog open={!!current} onOpenChange={resetModal}>
       <DialogContent className="sm:max-w-[425px] border-gray-300">
         <DialogHeader className="mb-0">
           <DialogTitle>{current.title}</DialogTitle>
@@ -30,4 +29,4 @@ const ModalContainer = () => {
   );
 };
 
-export default ModalContainer;
+export default ModalRenderer;

--- a/src/shared/components/ui/ProjectsMenu.tsx
+++ b/src/shared/components/ui/ProjectsMenu.tsx
@@ -6,30 +6,28 @@ import {
 } from '@/shared/components/shadcn/sidebar';
 import { Plus } from 'lucide-react';
 import { Link } from 'react-router';
-import useModalStore from '@/shared/store/useModalStore';
 import ProjectCreateModalContent from '@/features/project/components/ProjectCreateModalContent';
 import { useCreateProjectMutation } from '@/features/project/hooks/useCreateProjectMutation';
 import toast from 'react-hot-toast';
+import { useModal } from '@/shared/hooks/useModal';
 
 interface SidebarMenuItemProps {
   item: SidebarItem;
 }
 
 const ProjectsMenu = ({ item }: SidebarMenuItemProps) => {
-  const { openModal } = useModalStore();
-
   const createProjectMutation = useCreateProjectMutation();
+  const { showCustom } = useModal();
 
   const handleOpenProjectCreateModal = () => {
-    openModal({
-      type: 'custom',
+    showCustom({
       title: '프로젝트 생성하기',
       description: '프로젝트 이름을 입력하면, 새로운 프로젝트를 생성할 수 있어요.',
       content: (
         <ProjectCreateModalContent
           onConfirm={async (projectName) => {
             await createProjectMutation.mutateAsync(projectName);
-            toast.success(`프로젝트가 성공적으로 생성되었습니다!`);
+            toast.success('프로젝트가 성공적으로 생성되었습니다!');
           }}
         />
       ),

--- a/src/shared/hooks/useModal.ts
+++ b/src/shared/hooks/useModal.ts
@@ -8,14 +8,14 @@ interface CommonModalProps {
 }
 
 export const useModal = () => {
-  const { openModal, closeModal, backModal } = useModalStore();
+  const { openModal, resetModal, backModal } = useModalStore();
 
   const wrapButton = (btn: ModalButton): ModalButton => ({
     ...btn,
     onClick: async () => {
       try {
         await btn.onClick();
-        closeModal();
+        resetModal();
       } catch (err) {
         console.error('Modal action failed:', err);
       }
@@ -53,7 +53,7 @@ export const useModal = () => {
           variant: 'outline',
           onClick: async () => {
             await onCancel?.();
-            closeModal();
+            resetModal();
           },
         },
         wrapButton({
@@ -76,5 +76,5 @@ export const useModal = () => {
     });
   };
 
-  return { showAlert, showConfirm, showCustom, showSelect, closeModal, backModal };
+  return { showAlert, showConfirm, showCustom, showSelect, resetModal, backModal };
 };

--- a/src/shared/store/useModalStore.ts
+++ b/src/shared/store/useModalStore.ts
@@ -3,24 +3,33 @@ import type { ModalPayload } from '@/shared/types/modalTypes';
 
 interface ModalState {
   stack: ModalPayload[];
-  isLoading: boolean;
   openModal: (payload: ModalPayload) => void;
-  closeModal: () => void;
+  resetModal: () => void;
   backModal: () => void;
   setLoading: (isLoading: boolean) => void;
 }
 
 const useModalStore = create<ModalState>((set) => ({
   stack: [],
-  isLoading: false,
-  openModal: (payload) => set((state) => ({ stack: [...state.stack, payload] })),
-  closeModal: () => set({ stack: [], isLoading: false }),
+  openModal: (payload) =>
+    set((state) => ({ stack: [...state.stack, { ...payload, isLoading: false }] })),
+  resetModal: () => set({ stack: [] }),
   backModal: () =>
-    set((state) => ({
-      stack: state.stack.length > 1 ? state.stack.slice(0, -1) : [],
-      isLoading: false,
-    })),
-  setLoading: (isLoading) => set({ isLoading }),
+    set((state) => {
+      if (state.stack.length <= 1) return { stack: [] };
+      const newStack = state.stack.slice(0, -1);
+      const lastStackIndex = newStack.length - 1;
+      newStack[lastStackIndex] = { ...newStack[lastStackIndex], isLoading: false };
+      return { stack: newStack };
+    }),
+  setLoading: (isLoading) =>
+    set((state) => {
+      const stackLen = state.stack.length;
+      if (stackLen === 0) return state;
+      const updatedStack = [...state.stack];
+      updatedStack[stackLen - 1] = { ...updatedStack[stackLen - 1], isLoading };
+      return { stack: updatedStack };
+    }),
 }));
 
 export default useModalStore;

--- a/src/shared/types/modalTypes.ts
+++ b/src/shared/types/modalTypes.ts
@@ -13,4 +13,5 @@ export type ModalPayload = {
   description?: string;
   content?: ReactNode;
   buttons?: ModalButton[];
+  isLoading?: boolean;
 };


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약

- 모달 시스템에 대한 코드 리뷰 3차 멘토님 피드백을 반영했습니다.

<br/>

### ✨ 작업 내용

- **isLoading 상태의 용도 모호성을 해결했습니다**
-> isLoading을 전역상태로 관리하고 있었던 부분을 각 모달에 isLoading 속성을 포함시켜 개별적으로 관리할 수 있는 방식으로 수정했습니다.

- **closeModal 함수의 네이밍을 수정했습니다.**
-> closeModal은 "모달을 닫는다."라는 역할에 있어, backModal을 포함하는 넓은 의미를 가지는 것 같아서 "모달 전체를 닫는다." 라는 역할을 분명히 하기 위해 resetModal로 수정하였습니다. backModal은 "마지막 모달을 닫고, 이전 모달로 돌아간다." 라는 의미로 네이밍한 거라, 역할이 잘 보이는 것 같아서 backModal 유지했습니다.

- **ModalProvider이라는 네이밍을 Provider 대신, 역할을 명확히하는 ModalRenderer로 수정했습니다.**

- **useModalStore와 useModal의 역할을 분명히 하고, 진입점을 하나로 통일했습니다.**
-> ProjectsMenu에서 openModal을 사용하는 부분을 showCustom을 사용하도록 수정했습니다.

<br/>

### #️⃣ 연관 이슈

- Close #53 
