### PR TITLE
✨ 할 일 상세 페이지 - 상단바 UI 구현 

### DIFF
--- a/src/features/kanban/utils/tagUtils.ts
+++ b/src/features/kanban/utils/tagUtils.ts
@@ -24,7 +24,7 @@ export function generateTags(task: Task) {
   const tags: string[] = [];
 
   if (task.urgent) tags.push('긴급');
-  if (task.requiredReviewCount > 0) tags.push('검토필요');
+  if (task.review.requiredReviewCount > 0) tags.push('검토필요');
   if (task.tags) tags.push(...task.tags);
 
   return tags;

--- a/src/features/task-detail/components/TaskDetailTopTab.tsx
+++ b/src/features/task-detail/components/TaskDetailTopTab.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Button } from '@/shared/components/shadcn/button';
+import { ChevronLeft } from 'lucide-react';
+import type { Task } from '@/features/task/types/taskTypes';
+
+interface TaskDetailTopTabProps {
+  task: Task;
+}
+
+const TaskDetailTopTab = ({ task }: TaskDetailTopTabProps) => {
+  const navigate = useNavigate();
+  const [review, setReview] = useState(task.review);
+
+  const [isMyReviewed, setIsMyReviewed] = useState(false);
+
+  const handleReviewComplete = () => {
+    if (isMyReviewed) return;
+
+    const updatedApproved = review.approvedCount + 1;
+    const updatedPending = Math.max(review.requiredReviewCount - updatedApproved, 0);
+
+    setReview({
+      ...review,
+      approvedCount: updatedApproved,
+      pendingCount: updatedPending,
+      isCompleted: updatedApproved >= review.requiredReviewCount,
+    });
+
+    setIsMyReviewed(true);
+  };
+
+  return (
+    <nav className="flex flex-row items-center gap-3 justify-between w-full bg-gray-100 border-b border-gray-300 subtitle2-bold">
+      <div className="flex flex-row items-center gap-3">
+        <ChevronLeft
+          size={30}
+          strokeWidth={1}
+          className="h-12 ml-1 cursor-pointer"
+          onClick={() => navigate(-1)}
+        />
+        <div>{task.title}</div>
+      </div>
+
+      <div className="flex flex-row items-center gap-3 mr-4  cursor-default">
+        <div
+          className={`rounded-full border h-9 px-4 py-2 ${
+            isMyReviewed
+              ? 'border-green-600 bg-green-100 text-green-700'
+              : 'border-boost-blue-pressed bg-boost-blue/10 text-boost-blue-dark'
+          }`}
+        >
+          검토 완료 수 {review.approvedCount}/{review.requiredReviewCount}
+        </div>
+        <Button
+          onClick={handleReviewComplete}
+          className={`rounded-md ${
+            isMyReviewed
+              ? 'bg-green-600 hover:bg-green-600'
+              : 'bg-boost-blue hover:bg-boost-blue-hover'
+          }`}
+        >
+          {isMyReviewed ? '검토 완료됨' : '검토 완료하기'}
+        </Button>
+      </div>
+    </nav>
+  );
+};
+
+export default TaskDetailTopTab;

--- a/src/features/task/api/taskApi.ts
+++ b/src/features/task/api/taskApi.ts
@@ -16,7 +16,12 @@ let mockTasks: Task[] = [
     comments: 2,
     files: 3,
     urgent: true,
-    requiredReviewCount: 0,
+    review: {
+      requiredReviewCount: 4,
+      approvedCount: 2,
+      pendingCount: 0,
+      isCompleted: false,
+    },
   },
   {
     id: '2',
@@ -29,7 +34,12 @@ let mockTasks: Task[] = [
     comments: 0,
     files: 1,
     urgent: true,
-    requiredReviewCount: 2,
+    review: {
+      requiredReviewCount: 4,
+      approvedCount: 2,
+      pendingCount: 0,
+      isCompleted: false,
+    },
   },
   {
     id: '3',
@@ -42,7 +52,12 @@ let mockTasks: Task[] = [
     comments: 5,
     files: 0,
     urgent: false,
-    requiredReviewCount: 2,
+    review: {
+      requiredReviewCount: 4,
+      approvedCount: 2,
+      pendingCount: 0,
+      isCompleted: false,
+    },
   },
   {
     id: '4',
@@ -55,7 +70,12 @@ let mockTasks: Task[] = [
     comments: 1,
     files: 1,
     urgent: false,
-    requiredReviewCount: 0,
+    review: {
+      requiredReviewCount: 4,
+      approvedCount: 2,
+      pendingCount: 0,
+      isCompleted: false,
+    },
   },
 ];
 
@@ -78,7 +98,12 @@ export const kanbanApi = {
       files: 0,
       description: '할 일 설명',
       urgent: true,
-      requiredReviewCount: 2,
+      review: {
+        requiredReviewCount: 4,
+        approvedCount: 2,
+        pendingCount: 0,
+        isCompleted: false,
+      },
     };
     mockTasks.push(newTask);
     return newTask;

--- a/src/features/task/hooks/useCreateTaskMutation.ts
+++ b/src/features/task/hooks/useCreateTaskMutation.ts
@@ -23,7 +23,12 @@ export const useCreateTaskMutation = () => {
         files: 0,
         description: '',
         urgent: false,
-        requiredReviewCount: 2,
+        review: {
+          requiredReviewCount: 4,
+          approvedCount: 2,
+          pendingCount: 0,
+          isCompleted: false,
+        },
       };
 
       queryClient.setQueryData(['tasks'], (old: Task[]) => {

--- a/src/features/task/types/taskTypes.ts
+++ b/src/features/task/types/taskTypes.ts
@@ -14,7 +14,32 @@ export type Task = {
   assignees: string[];
   dueDate: string;
   urgent: boolean;
-  requiredReviewCount: number;
   files: number;
   comments: number;
+
+  review: {
+    requiredReviewCount: number;
+    approvedCount: number;
+    pendingCount: number;
+    isCompleted: boolean;
+  };
+};
+
+export const mockTask = {
+  id: '1',
+  title: '할 일 제목 예시',
+  description: 'top tab 테스트를 위한 임시 할 일입니다.',
+  status: 'TODO',
+  tags: ['FE'],
+  assignees: ['홍길동'],
+  dueDate: '2025-09-24',
+  urgent: false,
+  files: 0,
+  comments: 0,
+  review: {
+    requiredReviewCount: 4,
+    approvedCount: 2,
+    pendingCount: 0,
+    isCompleted: false,
+  },
 };

--- a/src/pages/TaskDetailPage.tsx
+++ b/src/pages/TaskDetailPage.tsx
@@ -1,5 +1,7 @@
 import FileSection from '@/features/task-detail/components/FileSection';
 import PDFViewer from '@/features/task-detail/components/PdfViewer';
+import TaskDetailTobTab from '@/features/task-detail/components/TaskDetailTopTab';
+import { mockTask } from '@/features/task/types/taskTypes';
 import { useState } from 'react';
 
 const TaskDetailPage = () => {
@@ -7,7 +9,7 @@ const TaskDetailPage = () => {
 
   return (
     <div className="flex flex-col h-screen">
-      <div className="bg-gray-500 h-12">상단바 영역</div>
+      <TaskDetailTobTab task={mockTask} />
       <div className="flex flex-1 overflow-hidden">
         <div id="left" className="flex flex-col w-6/10 overflow-hidden">
           {isPdfOpen ? (


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약

- 할 일 상세 페에지의 상단바 UI를 구현했습니다.

<br/>

### ✨ 작업 내용

- 뒤로가기 버튼과 할 일 제목, 검토/승인 관련 UI 를 세팅했습니다.
- 담당자가 아닌 팀원을 기준으로 한 UI 입니다 (검토하기 버튼) 
    <img width="1919" height="986" alt="image" src="https://github.com/user-attachments/assets/a6d0a4cf-b0cf-45b3-8383-856d942bbb95" />
    <img width="1919" height="983" alt="image" src="https://github.com/user-attachments/assets/0bf6402b-1446-4b44-bb33-ef8d80c36053" />



<br/>

### ❗ 참고 사항(선택)

- 추후, API 연동 후 담당자 여부에 따라 오른쪽 버튼 섹션 UI가 달라지도록 수정이 필요합니다.

<br/>

### #️⃣ 연관 이슈

- Close #49
