### PR TITLE
♻️ 디데이 산정 함수 리팩터링

### DIFF
--- a/src/features/kanban/components/TaskCard.tsx
+++ b/src/features/kanban/components/TaskCard.tsx
@@ -6,7 +6,7 @@ import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import type { Task } from '@/features/task/types/taskTypes';
 import { useDeleteTaskMutation } from '@/features/task/hooks/useDeleteTaskMutation';
-import { getDDay } from '@/shared/utils/dateUtils';
+import { calculateDDay } from '@/shared/utils/dateUtils';
 import { generateTags, getColorForTag } from '@/features/kanban/utils/tagUtils';
 
 interface Props {
@@ -81,7 +81,7 @@ const TaskCard = ({ task }: Props) => {
           <Calendar className="w-3.5 h-3.5" />
           {task.dueDate}
         </div>
-        <div className="ml-2 ">{getDDay(task.dueDate)}</div>
+        <div className="ml-2 ">{calculateDDay(task.dueDate, 'string')}</div>
       </div>
 
       {/* 담당자, 댓글 수, 파일 수 */}

--- a/src/features/task-detail/components/TaskDetailContent.tsx
+++ b/src/features/task-detail/components/TaskDetailContent.tsx
@@ -3,14 +3,13 @@ import { mockTask } from '@/features/task/types/taskTypes';
 import { Avatar, AvatarFallback } from '@/shared/components/shadcn/avatar';
 import { Badge } from '@/shared/components/shadcn/badge';
 import { User, Calendar, Tag, FileText, ChevronUp } from 'lucide-react';
-import { calculateDDay } from '@/features/task-detail/util/dDayUtiils';
+import { calculateDDay } from '@/shared/utils/dateUtils';
 import TagList from '@/features/task-detail/components/TagList';
 import ContentItem from '@/features/task-detail/components/ContentItem';
 import { useState } from 'react';
 
 const TaskDetailContent = () => {
   const tags = generateTags(mockTask);
-  const dDay = calculateDDay(mockTask.dueDate);
   const [showAllAssignees, setShowAllAssignees] = useState(false);
   const displayedAssignees = showAllAssignees ? mockTask.assignees : mockTask.assignees.slice(0, 2);
 
@@ -58,7 +57,9 @@ const TaskDetailContent = () => {
         <ContentItem icon={<Calendar className="w-5 h-5 text-xl text-gray-900" />} title="마감일">
           <div className="flex items-center gap-2">
             <p>{mockTask.dueDate}</p>
-            <Badge className={`text-gray-500 ${getColorForTag('마감일')}`}>{dDay}일 남음</Badge>
+            <Badge className={`text-gray-500 ${getColorForTag('마감일')}`}>
+              {calculateDDay(mockTask.dueDate, 'text')}
+            </Badge>
           </div>
         </ContentItem>
       </div>

--- a/src/features/task-detail/util/dDayUtiils.ts
+++ b/src/features/task-detail/util/dDayUtiils.ts
@@ -1,5 +1,0 @@
-export const calculateDDay = (dueDate?: string | null) => {
-  if (!dueDate) return null;
-  else
-    return String(Math.ceil((new Date(dueDate).getTime() - new Date().getTime()) / (1000 * 60 * 60 * 24)));
-};

--- a/src/shared/utils/dateUtils.ts
+++ b/src/shared/utils/dateUtils.ts
@@ -1,11 +1,30 @@
-export function getDDay(dueDate: string) {
-  if (!dueDate) return '';
+export const calculateDDay = (
+  dueDate?: string | null,
+  format: 'number' | 'string' | 'text' = 'number',
+) => {
+  if (!dueDate) return null;
+
   const due = new Date(dueDate);
   const today = new Date();
+
   due.setHours(0, 0, 0, 0);
   today.setHours(0, 0, 0, 0);
-  const diff = Math.floor((due.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
-  if (diff === 0) return 'D-DAY';
-  if (diff > 0) return `D-${diff}`;
-  return `D+${Math.abs(diff)}`;
-}
+
+  const diff = Math.round((due.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+
+  if (format === 'number') {
+    return diff;
+  }
+
+  if (format === 'string') {
+    if (diff === 0) return 'D-DAY';
+    return diff > 0 ? `D-${diff}` : `D+${Math.abs(diff)}`;
+  }
+
+  if (format === 'text') {
+    if (diff === 0) return '오늘 마감';
+    return diff > 0 ? `${diff}일 남음` : `${Math.abs(diff)}일 지남`;
+  }
+
+  return diff;
+};


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약

- 디데이 산정 함수를 통합하고, format 옵션을 추가하여 다양한 형식을 지원하도록 수정했습니다.

<br/>

### ✨ 작업 내용

- 기존의 getDDay, calculateDDay 함수를 통합했습니다.
- 기존에 getDDay는 무조건 반환으로 D-dd 형식으로 반환을 해서 다양한 형식을 지원하지 못했습니다.
-  calculateDDay는 숫자를 반환하지만 TaskDetailContent 에서 사용할 때 기간이 지나도 dd일 남음으로 표시되는 오류가 있었습니다.
- 그래서 format 옵션을 추가하여 다양한 형식을 지원하도록 수정했습니다.
  - 'number' → 숫자만 반환
  - 'string' → D- / D+ / D-DAY 반환
  - 'text' → "3일 남음", "2일 지남", "오늘 마감" 등 반환
- 자정 기준으로 날짜 비교하도록 하였습니다.
- 컴포넌트/다른 로직에서 재사용 가능하도록 개선했습니다.

<br/>

### #️⃣ 연관 이슈

- Close #64 
