### PR TITLE
✨ (#94) 나의 정보 페이지 임시 세팅 

### DIFF
--- a/src/app/routes/ProtectedRoute.tsx
+++ b/src/app/routes/ProtectedRoute.tsx
@@ -1,6 +1,6 @@
-// import { useAuthStore } from '@/features/auth/store/authStore';
+import { useAuthStore } from '@/features/auth/store/authStore';
 import type { ReactNode } from 'react';
-// import { Navigate, useLocation } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 
 interface ProtectedRouteProps {
   children: ReactNode;
@@ -8,15 +8,14 @@ interface ProtectedRouteProps {
 
 const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
   // TODO: 로그인 API 연동 후 아래 주석을 풀 것입니다.
-
-  // const { accessToken } = useAuthStore();
-  // const location = useLocation(); // 현재 URL 정보 가져오기
+  const { accessToken } = useAuthStore();
+  const location = useLocation(); // 현재 URL 정보 가져오기
 
   // accessToken 없으면 로그인 페이지로 이동, 이동 전 원래 위치 저장
   //TODO: 로그인 API 연동 후 아래 주석을 풀 것입니다.
-  // if (!accessToken) {
-  //   return <Navigate to="/login" state={{ from: location }} replace />;
-  // }
+  if (!accessToken) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
 
   return <>{children}</>;
 };

--- a/src/app/routes/Router.tsx
+++ b/src/app/routes/Router.tsx
@@ -12,6 +12,7 @@ import AvatarPickerPage from '@/pages/AvatarPickerPage';
 import KakaoCallbackPage from '@/pages/KakaoCallbackPage';
 import TaskDetailPage from '@/pages/TaskDetailPage';
 import ApiHealthCheck from '@/features/health-check/ApiHealthCheck';
+import MyInfoPage from '@/pages/MyInfoPage';
 
 export const ROUTE_PATH = {
   MAIN: '/',
@@ -24,6 +25,7 @@ export const ROUTE_PATH = {
   CALLBACK: '/auth/callback',
   API_CHECK: '/health',
   TASK_DETAIL: '/task-detail',
+  MY_INFO: '/my-info',
 };
 
 const PUBLIC_ROUTES = [
@@ -40,6 +42,7 @@ const PROTECTED_ROUTES = [
   { path: ROUTE_PATH.MYTASK, element: <MyTaskPage /> },
   { path: ROUTE_PATH.AVATAR, element: <AvatarPickerPage /> },
   { path: ROUTE_PATH.TASK_DETAIL, element: <TaskDetailPage /> },
+  { path: ROUTE_PATH.MY_INFO, element: <MyInfoPage /> },
 ];
 
 export const router = createBrowserRouter([

--- a/src/features/health-check/ApiHealthCheck.tsx
+++ b/src/features/health-check/ApiHealthCheck.tsx
@@ -7,7 +7,7 @@ export default function ApiHealthCheck() {
 
   useEffect(() => {
     api
-      .get('/health')
+      .get('https://api.boost.ai.kr/health')
       .then((res) => setResult(JSON.stringify(res.data)))
       .catch((err) => setResult('에러: ' + err.message));
   }, []);

--- a/src/pages/KakaoCallbackPage.tsx
+++ b/src/pages/KakaoCallbackPage.tsx
@@ -3,18 +3,22 @@ import { useEffect, useRef } from 'react';
 
 const KakaoCallbackPage = () => {
   const { mutate: kakaoLoginMutation } = useKakaoLoginMutation();
- const hasLoggedIn = useRef(false);
+  const hasLoggedIn = useRef(false);
+
   useEffect(() => {
-    if (hasLoggedIn.current) return 
+    if (hasLoggedIn.current) return;
+
     const params = new URLSearchParams(window.location.search);
     const code = params.get('code');
+
     if (code) {
       console.log('인가코드:', code);
       kakaoLoginMutation({ code });
       hasLoggedIn.current = true;
     }
-  }, []);
-  return null; //백그라운드 로그인 처리용 페이지이므로 null 처리
+  }, [kakaoLoginMutation]);
+
+  return null; // 백그라운드 로그인 처리용 페이지이므로 null 처리
 };
 
 export default KakaoCallbackPage;

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -14,14 +14,13 @@ const LoginPage = () => {
     import.meta.env.VITE_IS_LOCAL === 'true'
       ? 'http://localhost:5173/auth/callback'
       : 'https://boost.ai.kr/auth/callback';
-const clientId = import.meta.env.VITE_KAKAO_CLIENT_ID;
-
+  const clientId = import.meta.env.VITE_KAKAO_CLIENT_ID;
 
   const handleKakaoLogin = () => {
     const encodedRedirectUri = encodeURIComponent(redirectUri);
-    window.location.href = `https://kauth.kakao.com/oauth/authorize?client_id=${clientId}&redirect_uri=${encodedRedirectUri}&response_type=code
-`;
+    window.location.href = `https://kauth.kakao.com/oauth/authorize?client_id=${clientId}&redirect_uri=${encodedRedirectUri}&response_type=code`;
   };
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-purple-50 flex items-center justify-center p-4">
       {/* 배경 장식 요소들 */}

--- a/src/pages/MyInfoPage.tsx
+++ b/src/pages/MyInfoPage.tsx
@@ -1,0 +1,47 @@
+import { useAuthStore } from '@/features/auth/store/authStore';
+import { useEffect, useState } from 'react';
+
+interface JwtPayload {
+  sub: string;
+  auth: string;
+  name: string;
+  avatar: string;
+  exp: number;
+}
+
+const MyInfoPage = () => {
+  const [userInfo, setUserInfo] = useState<JwtPayload | null>(null);
+
+  useEffect(() => {
+    const token = useAuthStore.getState().accessToken;
+
+    if (token) {
+      const base64Payload = token.split('.')[1];
+      const payload = JSON.parse(
+        decodeURIComponent(
+          Array.from(atob(base64Payload))
+            .map((c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
+            .join(''),
+        ),
+      );
+      setUserInfo(payload);
+    }
+  }, []);
+
+  if (!userInfo) return <p>정보 없음</p>;
+
+  return (
+    <div className="p-4">
+      <h1>내 정보 (JWT 기반)</h1>
+      <ul>
+        {Object.entries(userInfo).map(([key, value]) => (
+          <li key={key}>
+            <strong>{key}</strong>: {value}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default MyInfoPage;

--- a/src/widgets/AppSidebar.tsx
+++ b/src/widgets/AppSidebar.tsx
@@ -13,13 +13,23 @@ import { LogOut } from 'lucide-react';
 import AppSidebarMenuItem from '@/features/sidebar/components/AppSidebarMenuItem';
 import AppSidebarProjectMenuItem from '@/features/sidebar/components/AppSidebarProjectMenuItem';
 import AppSidebarAlarmMenuItem from '@/features/alarm/components/AppSidebarAlarmMenuItem';
+import { useNavigate } from 'react-router-dom';
+import { ROUTE_PATH } from '@/app/routes/Router';
 
 const AppSidebar = () => {
   //TODO: 로그인된 사용자이면 아바타 이미지,로그아웃 버튼 나옴
+  const navigate = useNavigate();
+
+  const handleHeaderClick = () => {
+    navigate(ROUTE_PATH.MY_INFO);
+  };
 
   return (
     <Sidebar variant="sidebar" className="border-0 border-gray-300" collapsible="icon">
-      <SidebarHeader className="flex-row text-center pt-4 pb-4 pl-3 pr-3 h-18 bg-white">
+      <SidebarHeader
+        onClick={handleHeaderClick}
+        className="flex-row text-center pt-4 pb-4 pl-3 pr-3 h-18 bg-white cursor-pointer"
+      >
         <a className="flex justify-center items-center w-11 h-11 bg-boost-orange rounded-4xl">
           <img src={Profile} alt="" className="w-8 h-8" />
         </a>


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약

- jwt가 담고있는 사용자 정보를 추출하여 보여주는 나의 정보 페이지를 임시 구현했습니다.

<br/>

### ✨ 작업 내용

- 사이드바 상단 프로필 영역을 클릭하면 나의 정보 페이지로 이동하도록 했습니다.
- 나의 정보 페이지에서는 jwt가 담고 있는 사용자 정보를 간단하게 보여줍니다.

<br/>

### 🚦 테스트 플로우
#### 1. 로그인을 합니다. 
<img width="1919" height="986" alt="image" src="https://github.com/user-attachments/assets/ec48e3b4-7a82-4587-91f9-fa8c1cce5db5" />

<br/>

#### 2. 로그인이 되면 아바타 선택 페이지로 이동하게 되는데, 여기서 사이드바 프로필 영역을 클릭하면 나의 정보 페이지로 이동합니다.
<img width="1935" height="1001" alt="image" src="https://github.com/user-attachments/assets/728b548b-b12a-439b-a2bd-ac99c845252c" />

<br/>

#### 3. jwt에 담긴 나의 정보를 확인합니다.
<img width="1919" height="984" alt="image" src="https://github.com/user-attachments/assets/96c47636-79d4-4fd5-89b1-d5bb81b9e440" />


<br/>

### ❗ 참고 사항 (선택)
- ProtectedRoute 파일 주석 해제 해봤어요! 테스트 해보고싶어서 풀어두었는데, 현재 기능 구현 중이니 다시 주석처리 해주셔도 됩니다.
- 아바타 선택 페이지에서는 사이드바가 보이면 안될 것 같아요! 나중에 수정해야 할 것 같아요!
- 임시 구현한 것이니 자유롭게 수정하셔도 됩니다!

<br/>

### #️⃣ 연관 이슈

- Close #94 
