### PR TITLE
🐛 프로젝트 페이지 UI 오류 수정

### DIFF
--- a/src/pages/BoardPage.tsx
+++ b/src/pages/BoardPage.tsx
@@ -8,11 +8,17 @@ const BoardPage = () => {
   const [selectedTab, setSelectedTab] = useState<'state' | 'team-member'>('state');
 
   return (
-    <>
-      <FilterTab value={selectedTab} onChange={setSelectedTab} />
+    <div className="flex flex-col flex-1 min-h-0 h-full">
+      <section aria-label="filter" className="shrink-0">
+        <FilterTab value={selectedTab} onChange={setSelectedTab} />
+      </section>
+
       <Separator className="bg-gray-300" />
-      {selectedTab === 'state' ? <KanbanBoard /> : <TeamMemberBoard />}
-    </>
+
+      <section aria-label="board" className="overflow-x-auto flex-1">
+        {selectedTab === 'state' ? <KanbanBoard /> : <TeamMemberBoard />}
+      </section>
+    </div>
   );
 };
 

--- a/src/pages/ProjectPage.tsx
+++ b/src/pages/ProjectPage.tsx
@@ -11,7 +11,7 @@ const ProjectPage = () => {
   const currentPath = location.pathname.split('/').pop();
 
   const [activeTab, setActiveTab] = useState<'보드' | '파일' | '메모'>(
-    currentPath === 'files' ? '파일' : currentPath === 'memo' ? '메모' : '보드',
+    currentPath === 'file' ? '파일' : currentPath === 'memo' ? '메모' : '보드',
   );
 
   const handleChangeTab = (tab: '보드' | '파일' | '메모') => {
@@ -28,11 +28,22 @@ const ProjectPage = () => {
   }, [location.pathname, projectId, navigate]);
 
   return (
-    <div className="flex flex-col flex-1 min-w-0 h-screen">
-      <TobTab activeTab={activeTab} onChangeTab={handleChangeTab} />
-      <Header projectId={Number(projectId)} />
-      <Separator className="bg-gray-300" />
-      <Outlet />
+    <div className="flex flex-row flex-1 overflow-x-auto h-screen">
+      <div className="flex-1 flex flex-col min-w-0">
+        <nav aria-label="top-tab">
+          <TobTab activeTab={activeTab} onChangeTab={handleChangeTab} />
+        </nav>
+
+        <header aria-label="header">
+          <Header projectId={Number(projectId)} />
+        </header>
+
+        <Separator className="bg-gray-300" />
+
+        <section aria-label="board" className="overflow-x-auto flex-1">
+          <Outlet />
+        </section>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약

- 프로젝트 페이지 리팩터링 진행하면서 생긴 UI 오류를 수정했습니다.

<br/>

### ✨ 작업 내용
- 상단탭 기능을 구현하면서 프로젝트 페이지를 리팩터링했는데, 이 때 스타일 속성이 누락되어 화면에서 세로 스크롤이 생기는 오류가 발생했습니다!
  <img width="1919" height="990" alt="image" src="https://github.com/user-attachments/assets/ff158d9b-1659-4184-8ddc-f0c87ebfa560" />

<br/>

- 이를 기존 UI와 동일하게 세로 스크롤이 없도록 오류를 수정했습니다.
- 화면 스크롤이 없도록 하고, 스크롤이 있다면 content 영역 내에서만 스크롤이 되도록 수정했습니다.
  <img width="1919" height="986" alt="image" src="https://github.com/user-attachments/assets/c2c0826f-bf1c-4c5e-a446-0db2f5029368" />