### PR TITLE
🐛 (#123) 로그인 API 요청 body 구조 변경 대응

### DIFF
--- a/src/features/auth/api/authApi.ts
+++ b/src/features/auth/api/authApi.ts
@@ -7,9 +7,12 @@ import type {
 import { useAuthStore } from '@/features/auth/store/authStore';
 
 //카카오 로그인 (받아온 인가코드와 함께 BE에 전송)
-export const fetchKaKaoLogin = async ({ code }: KakaoLoginRequest): Promise<KakaoLoginResponse> => {
+export const fetchKaKaoLogin = async ({
+  code,
+  redirectUri,
+}: KakaoLoginRequest): Promise<KakaoLoginResponse> => {
   console.log('인가코드:', code);
-  const res = await api.post('/auth/login/kakao', { code });
+  const res = await api.post('/auth/login/kakao', { code, redirectUri });
   return res.data;
 };
 

--- a/src/features/auth/types/authTypes.ts
+++ b/src/features/auth/types/authTypes.ts
@@ -1,5 +1,6 @@
 export interface KakaoLoginRequest {
   code: string;
+  redirectUri: string;
 }
 
 export interface KakaoLoginResponse {

--- a/src/pages/KakaoCallbackPage.tsx
+++ b/src/pages/KakaoCallbackPage.tsx
@@ -11,8 +11,13 @@ const KakaoCallbackPage = () => {
     const params = new URLSearchParams(window.location.search);
     const code = params.get('code');
 
+    const redirectUri =
+      import.meta.env.VITE_IS_LOCAL === 'true'
+        ? 'http://localhost:5173/auth/callback'
+        : 'https://boost.ai.kr/auth/callback';
+
     if (code) {
-      kakaoLoginMutation({ code });
+      kakaoLoginMutation({ code, redirectUri });
       hasLoggedIn.current = true;
     }
   }, [kakaoLoginMutation]);


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약

- 로그인 요청 body를 새로운 구조에 맞게 수정 작업했습니다.

<br/>

### ✨ 작업 내용

- 인가코드와 리다이렉트 uri 를 body로 보내도록 수정했습니다.
- 로컬 환경 및 배포 환경에서 로그인 정상 동작 확인했습니다.
- 로그인 관련 타입 정의 업데이트 했습니다. 

<br/>

### ❗ 참고 사항(선택)

- 로컬 환경에서 reissue API 호출과 다른 조회 API 호출 사이에서 순서/동기화 문제로 에러가 발생하고 있습니다.
- 배포 환경에서 로그인 API 호출은 정상적으로 작동하나 CORS 에러로 내 정보 조회 API가 불가능한 상황입니다.

<br/>

### #️⃣ 연관 이슈

- Close #123 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Kakao login failures caused by missing redirect information. The app now sends both the authorization code and redirect URI, ensuring the callback completes correctly.
  * The callback page automatically determines the proper redirect URI for local and production environments, improving reliability and preventing login loops.
  * Enhances overall sign-in consistency without requiring any user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->