### PR TITLE
🐛 (#172) 참여 코드 만료됐을 때 버그 수정

### DIFF
--- a/src/features/project/hooks/useJoinCode.ts
+++ b/src/features/project/hooks/useJoinCode.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
-import { projectMembershipApi } from '@/features/project/api/projectMembershipApi';
 import { isAxiosError } from 'axios';
+import { projectMembershipApi } from '@/features/project/api/projectMembershipApi';
 
 export const useJoinCode = (projectId: string) => {
   const [joinCode, setJoinCode] = useState<string | null>(null);
@@ -14,21 +14,19 @@ export const useJoinCode = (projectId: string) => {
       setLoading(true);
 
       try {
-        // 참여 코드 조회
-        let codeInfo = await projectMembershipApi
+        const codeInfo = await projectMembershipApi
           .fetchJoinCode(projectId)
-          .catch((error: unknown) => {
-            // 코드 없음 → 생성
-            if (isAxiosError(error) && error.response?.status === 404) {
-              return projectMembershipApi.createJoinCode(projectId);
+          .catch(async (error: unknown) => {
+            if (isAxiosError(error)) {
+              if (error.response?.status === 404) {
+                return projectMembershipApi.createJoinCode(projectId);
+              }
+              if (error.response?.status === 400) {
+                return projectMembershipApi.createJoinCode(projectId);
+              }
             }
             throw error;
           });
-
-        // 만료된 코드면 새로 생성
-        if (!codeInfo || new Date(codeInfo.expiresAt) < new Date()) {
-          codeInfo = await projectMembershipApi.createJoinCode(projectId);
-        }
 
         setJoinCode(codeInfo.joinCode);
         setExpiresAt(codeInfo.expiresAt);


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약

- 참여 코드가 만료됐을 때 참여 코드가 모달에 안 뜨는 버그를 해결하기 위해 useJoinCode 코드를 수정했습니다

<br/>

### ✨ 작업 내용

- 이전에는 생성 시간을 받아와서 직접 계산하고 처리하는 방식이었습니다.
- 에러가 떠서 확인해보니 400 에러 코드에 만료 시간이 지났음을 알려주는 내용이 있어서 직접 계산하지 않고 에러 코드를 사용하는 방식을 사용해서 수정했습니다.

<br/>

### ❗ 참고 사항

- 테스트 코드 작성해서 확인하려다 시간이 좀 걸릴 것 같아서.. 참여코드 생성해놓고 만료됐을 때 확인해볼게요..!

<br/>

### #️⃣ 연관 이슈

- Close #172


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved join code generation reliability by expanding error handling to address additional failure scenarios.

* **Refactor**
  * Simplified join code processing by removing automatic expiration validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->