### PR TITLE
🐛 (#237) PDF 마커 디자인 오류 수정

### DIFF
--- a/src/features/comment/types/commentTypes.ts
+++ b/src/features/comment/types/commentTypes.ts
@@ -1,5 +1,6 @@
 import type { FileInfo } from '@/features/task-detail/types/taskDetailType';
 
+/* TODO: 댓글 목록 조회 응답 필드 확인 필요 */
 export interface AuthorInfo {
   memberId: string;
   name: string;

--- a/src/features/task-detail/components/PdfViewer/PdfOverlay.tsx
+++ b/src/features/task-detail/components/PdfViewer/PdfOverlay.tsx
@@ -31,11 +31,13 @@ const Overlay = ({ pageNumber, zoom, pageSize, onClick }: OverlayProps) => {
             <div
               key={uuidv4()}
               className={cn(
-                'flex items-center justify-center bg-boost-orange absolute w-7 h-7 rounded-[50%_50%_50%_0] -rotate-45 border-2 border-boost-orange shadow-md overflow-hidden cursor-pointer',
+                'flex items-center justify-center absolute w-7 h-7 rounded-[50%_50%_50%_0] -rotate-45 border-2 shadow-md overflow-hidden cursor-pointer',
                 isAnonymous && 'bg-gray-400',
               )}
+              /* TODO: 댓글 목록 조회 응답 필드 확인 필요 */
               style={{
                 backgroundColor: m.author?.backgroundColor,
+                borderColor: m.author?.backgroundColor,
                 left: `${left}%`,
                 top: `${top}%`,
                 transform: `translate(50%, -120%) scale(${zoom})`,
@@ -46,8 +48,9 @@ const Overlay = ({ pageNumber, zoom, pageSize, onClick }: OverlayProps) => {
               ) : (
                 <img
                   src={getAvatarSrc({ avatar: m.author?.avatar })}
+                  style={{ backgroundColor: user?.backgroundColor }}
                   alt={m.author?.name ?? 'avatar'}
-                  className="w-full h-full object-cover rotate-[45deg]"
+                  className="w-6 h-6 object-cover rotate-[45deg]"
                 />
               )}
             </div>
@@ -60,8 +63,10 @@ const Overlay = ({ pageNumber, zoom, pageSize, onClick }: OverlayProps) => {
           const top = 100 - (currentPin.fileY ? currentPin.fileY / pageSize.height : 0) * 100;
           return (
             <div
-              className="absolute w-8 h-8 rounded-[50%_50%_50%_0] -rotate-45 border-2 border-boost-orange shadow-md overflow-hidden cursor-pointer bg-boost-orange  transition-all duration-300 ease-in-out"
+              className="absolute flex items-center justify-center w-8 h-8 rounded-[50%_50%_50%_0] -rotate-45 border-2 shadow-md overflow-hidden cursor-pointer transition-all duration-300 ease-in-out"
               style={{
+                backgroundColor: user?.backgroundColor,
+                borderColor: user?.backgroundColor,
                 left: `${left}%`,
                 top: `${top}%`,
                 transform: `translate(50%, -120%) scale(${zoom})`,
@@ -71,7 +76,7 @@ const Overlay = ({ pageNumber, zoom, pageSize, onClick }: OverlayProps) => {
                 src={getAvatarSrc({ avatar: user?.avatar })}
                 alt="current pin"
                 style={{ backgroundColor: user?.backgroundColor }}
-                className="w-full h-full object-cover rotate-[45deg]"
+                className="w-6 h-6 object-cover rotate-[45deg]"
               />
             </div>
           );


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약

- PDF 마커 디자인 오류 수정했습니다.

<br/>

### ✨ 작업 내용

- 현재 자신의 핀 디자인 오류 수정했습니다. 오른쪽 하단이 현재 자신의 핀이고 왼쪽 상단이 기존에 존재한 핀입니다.
<img width="341" height="336" alt="image" src="https://github.com/user-attachments/assets/45cf56d1-b98c-4bec-9069-0866ea164b7f" />

<br/>

### ❗ 참고 사항

- 위 사진과 같이 기존 핀 목록에 대해 핀 렌더링될 때 댓글 목록 API 응답 author 필드 내용과 클라이언트 측 타입 내용이 달라 background를 받아올 수 없어 디자인 수정이 안되고 있습니다.
- 해당 댓글 작성자의 배경색을 마커에 반영하려면 authInfo에 배경색 필드가 추가돼야 할 것 같아요.

<br/>

### #️⃣ 연관 이슈

- Close #237 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * PDF 뷰어에서 주석 핀의 색상 시스템이 개선되었습니다.
  * 주석 아바타 표시 방식이 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->