### PR TITLE
♻️ (#224) 팀원 보드 프로필 아바타 배경색 반영

### DIFF
--- a/src/features/board/components/MemberBoard/MemberColumn.tsx
+++ b/src/features/board/components/MemberBoard/MemberColumn.tsx
@@ -81,13 +81,12 @@ const MemberColumn = ({ projectId, member }: MemberColumnProps) => {
           }}
           transition={{ duration: 0.2, ease: [0.25, 0.1, 0.25, 1] }}
         >
-          {/*📍TODO: 배경색 로직 추가 이후 보완 필요 */}
           <Avatar
             className={cn(
-              'flex items-center justify-center',
-              'bg-boost-yellow',
+              'flex items-center justify-center shadow-sm',
               isProfileCollapsible ? 'w-23 h-23' : 'w-27 h-27',
             )}
+            style={{ backgroundColor: member.backgroundColor }}
           >
             <AvatarFallback>{member.name[0]}</AvatarFallback>
             <AvatarImage


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약

- 팀원 보드에서 팀원들 아바타 배경색 반영했습니다.

<br/>

### ✨ 작업 내용

- 기존 boost yellow로 세팅되어있던 코드를 삭제하고 팀원 보드에 팀원 배경색 반영했습니다. 
<img width="1919" height="983" alt="image" src="https://github.com/user-attachments/assets/e182b6a6-8b22-4814-b5fc-06287e2be2e8" />

<br/>

### #️⃣ 연관 이슈

- Close #224


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 주요 변경사항

* **스타일**
  * 팀 멤버 아바타의 배경색이 정적인 단일 색상에서 각 멤버 정보에 따른 동적 색상으로 변경되었습니다.
  * 아바타에 미묘한 그림자 효과가 추가되어 시각적 계층구조가 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->