### PR TITLE
🚀 2025-11-10 배포

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,11 +7,6 @@ import { Toaster } from 'react-hot-toast';
 import AppInitializer from '@/app/AppInitializer';
 
 const queryClient = new QueryClient();
-// 아래는 에러바운더리 테스트용 코드입니다.
-// const BuggyComponent = () => {
-//   throw new Error('😱 일부러 발생시킨 에러!');
-//   return <div>안보일거야</div>;
-// };
 
 function App() {
   return (

--- a/src/app/AppInitializer.tsx
+++ b/src/app/AppInitializer.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, type ReactNode } from 'react';
 import { fetchRefreshToken } from '@/features/auth/api/authApi';
-import { useAuthStore } from '@/features/auth/store/authStore';
+import { useAuthStore } from '@/features/auth/store/useAuthStore';
 import { useMyInfoQuery } from '@/features/settings/hooks/useMyInfoQuery';
 import SplashScreen from '@/pages/SplashScreen';
 import type { User } from '@/features/user/types/userTypes';
@@ -30,7 +30,7 @@ const AppInitializer = ({ children }: AppInitializerProps) => {
     const init = async () => {
       try {
         const { accessToken } = await fetchRefreshToken();
-        setAuth({ token: accessToken });
+        setAuth({ accessToken: accessToken });
 
         const userResponse = await refetchUser();
 

--- a/src/app/routes/ProtectedRoute.tsx
+++ b/src/app/routes/ProtectedRoute.tsx
@@ -1,4 +1,4 @@
-import { useAuthStore } from '@/features/auth/store/authStore';
+import { useAuthStore } from '@/features/auth/store/useAuthStore';
 import type { ReactNode } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 import { ROUTE_PATH } from '@/app/routes/Router';

--- a/src/features/auth/hooks/useKakaoLoginMutation.ts
+++ b/src/features/auth/hooks/useKakaoLoginMutation.ts
@@ -1,10 +1,11 @@
 import { useMutation } from '@tanstack/react-query';
 import type { KakaoLoginRequest, KakaoLoginResponse } from '@/features/auth/types/authTypes';
-import { useAuthStore } from '@/features/auth/store/authStore';
+import { useAuthStore } from '@/features/auth/store/useAuthStore';
 import { fetchKaKaoLogin } from '@/features/auth/api/authApi';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { ROUTE_PATH } from '@/app/routes/Router';
 import toast from 'react-hot-toast';
+import type { User } from '@/features/user/types/userTypes';
 
 export const useKakaoLoginMutation = () => {
   const navigate = useNavigate();
@@ -16,14 +17,28 @@ export const useKakaoLoginMutation = () => {
   return useMutation({
     mutationFn: async (data: KakaoLoginRequest) => {
       const loginData: KakaoLoginResponse = await fetchKaKaoLogin(data);
-      setAuth({ token: loginData.accessToken, user: loginData.memberResponseDto });
+
+      const userToStore: User = {
+        ...loginData.memberResponseDto,
+        avatar: loginData.isNewUser ? undefined : loginData.memberResponseDto.avatar,
+        backgroundColor: loginData.isNewUser
+          ? undefined
+          : loginData.memberResponseDto.backgroundColor,
+        notificationEnabled: loginData.isNewUser
+          ? undefined
+          : loginData.memberResponseDto.notificationEnabled,
+      };
+
+      setAuth({ accessToken: loginData.accessToken, user: userToStore });
       return loginData.isNewUser;
     },
     onSuccess: (isNewUser) => {
       toast.success('로그인이 완료되었습니다.');
-      if (from) navigate(from, { replace: true });
-      else if (isNewUser) navigate(ROUTE_PATH.AVATAR);
+
+      if (isNewUser) navigate(ROUTE_PATH.AVATAR);
+      else if (from) navigate(from, { replace: true });
       else navigate(ROUTE_PATH.MY_TASK);
+
       localStorage.removeItem('login_from');
     },
     onError: () => toast.error('로그인 중 오류가 발생했습니다 😢'),

--- a/src/features/auth/hooks/useLogoutMutation.ts
+++ b/src/features/auth/hooks/useLogoutMutation.ts
@@ -1,6 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 import { fetchLogout } from '@/features/auth/api/authApi';
-import { useAuthStore } from '@/features/auth/store/authStore';
+import { useAuthStore } from '@/features/auth/store/useAuthStore';
 import toast from 'react-hot-toast';
 
 export const useLogoutMutation = () => {

--- a/src/features/auth/store/useAuthStore.ts
+++ b/src/features/auth/store/useAuthStore.ts
@@ -4,7 +4,7 @@ import { create } from 'zustand';
 interface AuthState {
   user: User | null;
   accessToken: string | null;
-  setAuth: (payload: { user?: Partial<User>; token?: string }) => void;
+  setAuth: (payload: { user?: Partial<User>; accessToken?: string }) => void;
   clearAuth: () => void;
   isInitializing: boolean;
   setIsInitializing: (status: boolean) => void;
@@ -15,10 +15,10 @@ export const useAuthStore = create<AuthState>((set) => ({
   accessToken: null,
   isInitializing: true,
   setIsInitializing: (status) => set({ isInitializing: status }),
-  setAuth: ({ user, token }) =>
+  setAuth: ({ user, accessToken }) =>
     set((prevState) => ({
       user: user ? ({ ...prevState.user, ...user } as User) : prevState.user,
-      accessToken: token ?? prevState.accessToken,
+      accessToken: accessToken ?? prevState.accessToken,
     })),
 
   clearAuth: () => set({ user: null, accessToken: null }),

--- a/src/features/avatar-picker/components/AvatarSelector.tsx
+++ b/src/features/avatar-picker/components/AvatarSelector.tsx
@@ -7,7 +7,7 @@ const AvatarSelector = () => {
       <div className="relative group">
         <div className="absolute inset-0 bg-gradient-to-r from-boost-orange via-boost-blue to-purple-500 rounded-full blur-lg opacity-20 group-hover:opacity-30 transition-opacity duration-300 scale-110" />
         <CurrentAvatar />
-        <AvatarsDrawer />
+        <AvatarsDrawer showConfirmButton={true} />
       </div>
     </div>
   );

--- a/src/features/avatar-picker/components/AvatarsDrawer.tsx
+++ b/src/features/avatar-picker/components/AvatarsDrawer.tsx
@@ -15,7 +15,7 @@ import { avatarList } from '@/features/avatar-picker/utils/avatarUtils';
 import toast from 'react-hot-toast';
 import { useUpdateAvatarMutation } from '@/features/settings/hooks/useUpdateAvatarMutation';
 import { useEffect, useState } from 'react';
-import { useAuthStore } from '@/features/auth/store/authStore';
+import { useAuthStore } from '@/features/auth/store/useAuthStore';
 import tinycolor from 'tinycolor2';
 import { Button } from '@/shared/components/shadcn/button';
 

--- a/src/features/avatar-picker/components/AvatarsDrawer.tsx
+++ b/src/features/avatar-picker/components/AvatarsDrawer.tsx
@@ -50,20 +50,20 @@ const AvatarsDrawer = ({ showEditButton = true, showConfirmButton }: AvatarsDraw
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isDrawerOpen, user?.avatar, user?.backgroundColor]);
 
-  const handleConfirm = () => {
+  const handleConfirm = async () => {
     if (!selectedAvatarId || !selectedBgColor) {
       toast.error('아바타와 배경색을 모두 선택해주세요!');
       return;
     }
 
-    updateAvatar(
-      { avatar: selectedAvatarId, backgroundColor: selectedBgColor },
-      {
-        onSuccess: () => {
-          closeDrawer();
-        },
-      },
-    );
+    try {
+      await updateAvatar({ avatar: selectedAvatarId, backgroundColor: selectedBgColor });
+      closeDrawer();
+      toast.success('아바타가 성공적으로 업데이트되었습니다!');
+    } catch (error) {
+      console.log('아바타 업데이트 실패', error);
+      toast.error('아바타 업데이트에 실패했습니다 😢');
+    }
   };
 
   return (

--- a/src/features/board/components/MemberBoard/MemberBoard.tsx
+++ b/src/features/board/components/MemberBoard/MemberBoard.tsx
@@ -43,6 +43,8 @@ const MemberBoard = ({ projectId }: MemberBoardProps) => {
       ]
     : [];
 
+  const isAllScoreZero = projectMembersWithBoosting?.every((m) => m.totalScore === 0) ?? true;
+
   const { data: doneData } = useInfiniteProjectTasksByStatusQuery(projectId ?? '', 'DONE');
   const doneTasks: TaskListItem[] = doneData?.pages.flatMap((page) => page.tasks) ?? [];
 
@@ -87,7 +89,12 @@ const MemberBoard = ({ projectId }: MemberBoardProps) => {
       <div ref={scrollRef} className="overflow-x-auto overflow-y-hidden h-full py-2 px-1">
         <div className="flex gap-3 min-w-max h-full items-stretch">
           {(sortedMembersWithBoosting ?? []).map((member: MemberWithBoosting) => (
-            <MemberColumn key={member.id} projectId={projectId ?? ''} member={member} />
+            <MemberColumn
+              key={member.id}
+              projectId={projectId ?? ''}
+              member={member}
+              isAllScoreZero={isAllScoreZero}
+            />
           ))}
 
           {/* 완료 컬럼 */}

--- a/src/features/board/components/MemberBoard/MemberBoard.tsx
+++ b/src/features/board/components/MemberBoard/MemberBoard.tsx
@@ -7,7 +7,7 @@ import { useHorizontalScroll } from '@/features/board/hooks/useHorizontalScroll'
 import type { TaskListItem } from '@/features/task/types/taskTypes';
 import { useProjectMembersQuery } from '@/features/project/hooks/useProjectMembersQuery';
 import { useProjectBoostingScoresQuery } from '@/features/project/hooks/useProjectBoostingScoresQuery';
-import { useAuthStore } from '@/features/auth/store/authStore';
+import { useAuthStore } from '@/features/auth/store/useAuthStore';
 import type { MemberWithBoosting } from '@/features/project/types/projectTypes';
 import { combineMembersWithBoostingScores } from '@/features/project/utils/memberUtils';
 import FullPageLoader from '@/shared/components/ui/loading/FullPageLoader';

--- a/src/features/board/components/MemberBoard/MemberColumn.tsx
+++ b/src/features/board/components/MemberBoard/MemberColumn.tsx
@@ -14,7 +14,7 @@ import { getTaskCountByMember } from '@/features/task/utils/taskUtils';
 import { getAvatarSrc } from '@/features/avatar-picker/utils/avatarUtils';
 import type { MemberWithBoosting } from '@/features/project/types/projectTypes';
 import Crown from '@/shared/assets/images/boost/crown.png';
-import { useAuthStore } from '@/features/auth/store/authStore';
+import { useAuthStore } from '@/features/auth/store/useAuthStore';
 import BoostingScoreInfoCard from '@/features/board/components/MemberBoard/BoostingScoreInfoCard';
 import { useTagFilterStore } from '@/features/tag/store/useTagFilterStore';
 import InlineLoader from '@/shared/components/ui/loading/InlineLoader';

--- a/src/features/board/components/MemberBoard/MemberColumn.tsx
+++ b/src/features/board/components/MemberBoard/MemberColumn.tsx
@@ -22,13 +22,13 @@ import InlineLoader from '@/shared/components/ui/loading/InlineLoader';
 interface MemberColumnProps {
   projectId: string;
   member: MemberWithBoosting;
+  isAllScoreZero: boolean;
 }
 
-const MemberColumn = ({ projectId, member }: MemberColumnProps) => {
+const MemberColumn = ({ projectId, member, isAllScoreZero }: MemberColumnProps) => {
   const [isProfileCollapsible, setIsProfileCollapsible] = useState(false);
   const [isMouseInside, setIsMouseInside] = useState(false);
   const currentUser = useAuthStore((state) => state.user);
-
   const { selectedTags } = useTagFilterStore();
 
   const { data: memberTaskCountMap } = useProjectTaskCountByMemberQuery(projectId);
@@ -96,7 +96,7 @@ const MemberColumn = ({ projectId, member }: MemberColumnProps) => {
           }}
           transition={{ duration: 0.2, ease: [0.25, 0.1, 0.25, 1] }}
         >
-          {member.rank === 1 && (
+          {member.rank === 1 && !isAllScoreZero && (
             <motion.img
               src={Crown}
               alt="1st"

--- a/src/features/comment/constants/personaConstants.ts
+++ b/src/features/comment/constants/personaConstants.ts
@@ -1,4 +1,4 @@
 export const PERSONA = {
   BOO: 'BOO',
 } as const;
-export type PersonaType = string| null;
+export type PersonaType = string | null;

--- a/src/features/comment/constants/personaConstants.ts
+++ b/src/features/comment/constants/personaConstants.ts
@@ -1,4 +1,4 @@
 export const PERSONA = {
   BOO: 'BOO',
 } as const;
-export type PersonaType = (typeof PERSONA)[keyof typeof PERSONA] | null;
+export type PersonaType = string| null;

--- a/src/features/comment/constants/personaConstants.ts
+++ b/src/features/comment/constants/personaConstants.ts
@@ -1,4 +1,4 @@
 export const PERSONA = {
   BOO: 'BOO',
 } as const;
-export type PersonaType = string | null;
+export type PersonaType = (typeof PERSONA)[keyof typeof PERSONA] | null;

--- a/src/features/comment/hooks/useCreateCommentMutation.ts
+++ b/src/features/comment/hooks/useCreateCommentMutation.ts
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { commentApi, type CreateCommentRequest } from '@/features/comment/api/commentApi';
 import { v4 as uuidv4 } from 'uuid';
 import type { CommentType } from '@/features/comment/types/commentTypes';
-import { useAuthStore } from '@/features/auth/store/authStore';
+import { useAuthStore } from '@/features/auth/store/useAuthStore';
 import { COMMENT_QUERY_KEYS } from '@/features/comment/api/commentQueryKey';
 import toast from 'react-hot-toast';
 

--- a/src/features/comment/types/commentTypes.ts
+++ b/src/features/comment/types/commentTypes.ts
@@ -25,5 +25,5 @@ export interface CommentUIType extends CommentType {
   isPinned?: boolean;
   commentId: string;
   persona: string | null;
-  isAnonymous:boolean
+  isAnonymous: boolean;
 }

--- a/src/features/comment/types/commentTypes.ts
+++ b/src/features/comment/types/commentTypes.ts
@@ -1,3 +1,4 @@
+import type { PersonaType } from '@/features/comment/constants/personaConstants';
 import type { FileInfo } from '@/features/task-detail/types/taskDetailType';
 
 /* TODO: 댓글 목록 조회 응답 필드 확인 필요 */
@@ -11,7 +12,7 @@ export interface AuthorInfo {
 export interface CommentType {
   commentId: string;
   content: string;
-  persona: string | null;
+  persona: PersonaType;
   isAnonymous: boolean;
   fileInfo?: FileInfo | null;
   authorInfo: AuthorInfo;
@@ -24,6 +25,6 @@ export interface CommentUIType extends CommentType {
   timeAgo: string;
   isPinned?: boolean;
   commentId: string;
-  persona: string | null;
+  persona: PersonaType;
   isAnonymous: boolean;
 }

--- a/src/features/comment/types/commentTypes.ts
+++ b/src/features/comment/types/commentTypes.ts
@@ -25,4 +25,5 @@ export interface CommentUIType extends CommentType {
   isPinned?: boolean;
   commentId: string;
   persona: string | null;
+  isAnonymous:boolean
 }

--- a/src/features/comment/utils/commentUtils.ts
+++ b/src/features/comment/utils/commentUtils.ts
@@ -14,7 +14,8 @@ export const extractPinsFromComments = (comments: CommentUIType[]): PinWithAutho
         isAnonymous: c.isAnonymous,
         commentId: c.commentId,
       },
-    })) as PinWithAuthor[];
+    persona:c.persona
+      })) as PinWithAuthor[];
 // 날짜 문자열을 '방금 전 / N분 전 / N시간 전 / N일 전' 형식으로 변환하는 유틸 함수
 export const formatTimeAgo = (createdAt: string) => {
   const safeDate = new Date(createdAt.split('.')[0]);

--- a/src/features/comment/utils/commentUtils.ts
+++ b/src/features/comment/utils/commentUtils.ts
@@ -6,16 +6,18 @@ export const extractPinsFromComments = (comments: CommentUIType[]): PinWithAutho
     .filter((c) => c.fileInfo)
     .map((c) => ({
       ...(c.fileInfo as FileInfo),
+
+      isAnonymous: c.isAnonymous,
+      persona: c.persona,
       author: {
         memberId: c.authorInfo.memberId,
         name: c.authorInfo.name,
         avatar: c.authorInfo.avatar,
         backgroundColor: c.authorInfo.backgroundColor,
-        isAnonymous: c.isAnonymous,
-        commentId: c.commentId,
       },
-    persona:c.persona
-      })) as PinWithAuthor[];
+      commentId: c.commentId,
+    })) as PinWithAuthor[];
+
 // 날짜 문자열을 '방금 전 / N분 전 / N시간 전 / N일 전' 형식으로 변환하는 유틸 함수
 export const formatTimeAgo = (createdAt: string) => {
   const safeDate = new Date(createdAt.split('.')[0]);

--- a/src/features/file/api/fileApi.ts
+++ b/src/features/file/api/fileApi.ts
@@ -3,7 +3,7 @@ import api from '@/shared/api/axiosInstance';
 
 export const fileApi = {
   // 프로젝트 파일 목록 조회 (커서 기반 페이지네이션)
-  fetchFiles: async (projectId: string, cursor?: string, limit = 8) => {
+  fetchFiles: async (projectId: string, cursor?: string, limit = 6) => {
     const { data } = await api.get(`/projects/${projectId}/files`, {
       params: { cursor, limit },
     });

--- a/src/features/file/hooks/useProjectFilesQuery.ts
+++ b/src/features/file/hooks/useProjectFilesQuery.ts
@@ -6,7 +6,7 @@ export const useProjectFilesQuery = (projectId: string) => {
   return useInfiniteQuery<ProjectFilesResponse, Error>({
     queryKey: ['projectFiles', projectId],
     queryFn: ({ pageParam }) =>
-      fileApi.fetchFiles(projectId, typeof pageParam === 'string' ? pageParam : undefined, 8),
+      fileApi.fetchFiles(projectId, typeof pageParam === 'string' ? pageParam : undefined, 6),
     getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.nextCursor : undefined),
     enabled: !!projectId,
     initialPageParam: undefined,

--- a/src/features/notifications/api/notificationsApi.ts
+++ b/src/features/notifications/api/notificationsApi.ts
@@ -6,7 +6,7 @@ import type {
 import api from '@/shared/api/axiosInstance';
 
 export const notificationsApi = {
-  fetchNotifications: async (cursor?: string, limit = 8): Promise<NotificationsResponse> => {
+  fetchNotifications: async (cursor?: string, limit = 6): Promise<NotificationsResponse> => {
     const { data } = await api.get<NotificationsResponse>('/notifications', {
       params: { cursor, limit },
     });

--- a/src/features/notifications/components/NotificationDropdownMenu.tsx
+++ b/src/features/notifications/components/NotificationDropdownMenu.tsx
@@ -1,10 +1,10 @@
 import { DropdownMenuContent } from '@/shared/components/shadcn/dropdown-menu';
 import { useNotificationCountsQuery } from '@/features/notifications/hooks/useNotificationCountsQuery';
 import { useMarkNotificationAsReadMutation } from '@/features/notifications/hooks/useMarkNotificationAsReadMutation';
-import { useMarkAllNotificationAsRead } from '@/features/notifications/hooks/useMarkAllNotificationAsRead';
 import NotificationDropdownHeader from '@/features/notifications/components/notificationDropdownMenu/NotificationDropdownHeader';
 import NotificationList from '@/features/notifications/components/notificationDropdownMenu/NotificationList';
 import type { NotificationItem } from '@/features/notifications/types/NotificationsType';
+import { useMarkAllNotificationAsReadMutation } from '@/features/notifications/hooks/useMarkAllNotificationAsReadMutation';
 
 export interface NotificationDropdownMenuProps {
   notifications: NotificationItem[];
@@ -21,7 +21,7 @@ const NotificationDropdownMenu = ({
 }: NotificationDropdownMenuProps) => {
   const { data: notificationCountData } = useNotificationCountsQuery();
   const { mutate: markAsRead } = useMarkNotificationAsReadMutation();
-  const { mutate: markAllAsRead } = useMarkAllNotificationAsRead();
+  const { mutate: markAllAsRead } = useMarkAllNotificationAsReadMutation();
 
   return (
     <DropdownMenuContent

--- a/src/features/notifications/components/notificationDropdownMenu/NotificationDropdownHeader.tsx
+++ b/src/features/notifications/components/notificationDropdownMenu/NotificationDropdownHeader.tsx
@@ -16,8 +16,10 @@ const NotificationDropdownHeader = ({
 
       {unreadCount ? (
         <div className="flex items-center gap-2">
-          <span className="text-xs text-gray-500">안읽음 {unreadCount}</span>
-          <Button onClick={onMarkAll}>모두 읽음</Button>
+          <span className="label2-regular text-gray-500">안읽음 {unreadCount}</span>
+          <Button variant="defaultBoost" onClick={onMarkAll} className="label2-regular px-3 py-0">
+            모두 읽음
+          </Button>
         </div>
       ) : null}
     </DropdownMenuLabel>

--- a/src/features/notifications/components/notificationDropdownMenu/NotificationList.tsx
+++ b/src/features/notifications/components/notificationDropdownMenu/NotificationList.tsx
@@ -20,7 +20,7 @@ const NotificationList = ({
   isFetchingNextPage,
 }: NotificationListProps) => {
   return (
-    <div className="flex-1 overflow-y-auto">
+    <div className="flex-1 overflow-y-auto overflow-x-hidden">
       {notifications.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-12 text-gray-500">
           <Bell className="h-12 w-12 mb-3 opacity-20" />

--- a/src/features/notifications/components/notificationDropdownMenu/NotificationListItem.tsx
+++ b/src/features/notifications/components/notificationDropdownMenu/NotificationListItem.tsx
@@ -15,32 +15,22 @@ const NotificationListItem = ({ notification, onMarkAsRead }: NotificationListIt
   return (
     <DropdownMenuItem
       className={cn(
-        'group relative px-4 py-3 transition-colors',
+        'group relative p-3 transition-colors m-1 rounded-xl',
         'hover:bg-transparent focus:bg-transparent',
         !n.read && 'bg-blue-50 hover:bg-blue-50 focus:bg-blue-50',
       )}
     >
-      <div className="flex gap-3 w-full pr-4">
-        <div className="flex-shrink-0 w-10 h-10 rounded-full flex items-center justify-center bg-blue-100">
-          <Bell className="w-5 h-5 text-blue-600" />
+      <div className="flex gap-3 w-full">
+        <div className="flex-shrink-0 w-10 h-10 rounded-full flex items-center justify-center bg-blue-100 mr-1">
+          <Bell className="w-5 h-5 text-boost-blue" />
         </div>
 
         <div className="flex-1 min-w-0">
-          <p
-            className={cn(
-              'text-sm font-medium truncate',
-              n.read ? 'text-gray-500/70' : 'text-gray-800',
-            )}
-          >
+          <p className={cn('body2-bold', n.read ? 'text-gray-500/70' : 'text-gray-800')}>
             {n.title}
           </p>
 
-          <p
-            className={cn(
-              'text-xs line-clamp-2 mb-1',
-              n.read ? 'text-gray-500/70' : 'text-gray-700',
-            )}
-          >
+          <p className={cn('text-xs mb-1', n.read ? 'text-gray-500/70' : 'text-gray-700')}>
             {n.message}
           </p>
 
@@ -65,7 +55,7 @@ const NotificationListItem = ({ notification, onMarkAsRead }: NotificationListIt
             onMarkAsRead(n.id);
           }}
         >
-          <Check className="h-4 w-4 text-blue-700" />
+          <Check className="h-4 w-4 text-boost-blue" />
         </Button>
       )}
     </DropdownMenuItem>

--- a/src/features/notifications/hooks/useMarkAllNotificationAsReadMutation.ts
+++ b/src/features/notifications/hooks/useMarkAllNotificationAsReadMutation.ts
@@ -3,7 +3,7 @@ import { NOTIFICATION_QUERY_KEYS } from '@/features/notifications/constants/noti
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 
-export const useMarkAllNotificationAsRead = () => {
+export const useMarkAllNotificationAsReadMutation = () => {
   const queryClient = useQueryClient();
 
   return useMutation({

--- a/src/features/project/components/ProjectJoinModal/ProjectJoinCodeInputModalContent.tsx
+++ b/src/features/project/components/ProjectJoinModal/ProjectJoinCodeInputModalContent.tsx
@@ -33,13 +33,13 @@ const ProjectJoinCodeInputModalContent = ({
 
         switch (type) {
           case ERROR.JOIN_CODE.NOT_FOUND.type:
-            toast.error('잘못된 참여 코드입니다.');
+            toast.error('참여 코드를 찾을 수 없습니다.');
             break;
           case ERROR.MEMBER.ALREADY_JOINED.type:
             toast.error('이미 참여하고 있는 프로젝트입니다.');
             break;
           default:
-            toast.error('프로젝트 참여에 실패했습니다.');
+            toast.error('잘못된 참여 코드입니다.');
         }
       } else {
         toast.error('알 수 없는 오류가 발생했습니다.');

--- a/src/features/project/components/ProjectJoinModal/ProjectJoinCodeViewModalContent.tsx
+++ b/src/features/project/components/ProjectJoinModal/ProjectJoinCodeViewModalContent.tsx
@@ -6,7 +6,7 @@ import toast from 'react-hot-toast';
 import { Copy, RefreshCw } from 'lucide-react';
 import { useJoinCode } from '@/features/project/hooks/useJoinCode';
 import { formatSecondsToHHMMSS, getRemainingSeconds } from '@/shared/utils/dateUtils';
-import { useCreateJoinCodeMutation } from '@/features/project/hooks/useCreateJoincodeMutation';
+import { useCreateJoinCodeMutation } from '@/features/project/hooks/useCreateJoinCodeMutation';
 
 interface ProjectJoinCodeViewModalContentProps {
   projectId: string;

--- a/src/features/project/components/ProjectJoinModal/ProjectJoinCodeViewModalContent.tsx
+++ b/src/features/project/components/ProjectJoinModal/ProjectJoinCodeViewModalContent.tsx
@@ -6,6 +6,7 @@ import toast from 'react-hot-toast';
 import { Copy, RefreshCw } from 'lucide-react';
 import { useJoinCode } from '@/features/project/hooks/useJoinCode';
 import { formatSecondsToHHMMSS, getRemainingSeconds } from '@/shared/utils/dateUtils';
+import { useCreateJoinCodeMutation } from '@/features/project/hooks/useCreateJoincodeMutation';
 
 interface ProjectJoinCodeViewModalContentProps {
   projectId: string;
@@ -13,11 +14,16 @@ interface ProjectJoinCodeViewModalContentProps {
 
 const ProjectJoinCodeViewModalContent = ({ projectId }: ProjectJoinCodeViewModalContentProps) => {
   const { joinCode, expiresAt, loading, loadJoinCode } = useJoinCode(projectId);
+  const { mutate: createJoinCode } = useCreateJoinCodeMutation(projectId);
   const { resetModal } = useModalStore();
   const [remainingTime, setRemainingTime] = useState<number | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
 
   useEffect(() => {
-    if (!expiresAt) return;
+    if (!expiresAt) {
+      setRemainingTime(null);
+      return;
+    }
 
     const updateRemainingTime = () => setRemainingTime(getRemainingSeconds(expiresAt));
     updateRemainingTime();
@@ -38,47 +44,55 @@ const ProjectJoinCodeViewModalContent = ({ projectId }: ProjectJoinCodeViewModal
   };
 
   const handleRefresh = async () => {
+    setIsCreating(true);
     try {
-      await loadJoinCode();
-      toast.success('새 참여 코드가 발급되었습니다!');
-    } catch (error) {
-      toast.error('참여 코드 재발급에 실패했습니다.');
-      console.error('참여 코드 재발급 실패:', error);
+      createJoinCode(undefined, {
+        onSuccess: () => {
+          loadJoinCode();
+          toast.success('새 참여 코드가 발급되었습니다!');
+        },
+        onError: (err) => {
+          toast.error('참여 코드 재발급에 실패했습니다.');
+          console.error('참여 코드 재발급 실패:', err);
+        },
+        onSettled: () => {
+          setIsCreating(false);
+        },
+      });
+    } catch (err) {
+      setIsCreating(false);
+      toast.error('참여 코드 재발급 중 에러가 발생했습니다.');
+      console.error(err);
     }
   };
 
   return (
     <>
-      <div className="py-4 flex flex-col gap-2">
+      <div className="py-4 flex flex-col gap-3">
         {loading ? (
           <p>참여 코드를 불러오는 중입니다!</p>
         ) : joinCode ? (
           <>
-            <p className="subtitle2-bold flex items-center justify-between">
-              참여 코드 <span className="subtitle2-regular">{joinCode}</span>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={handleCopy}
-                className="flex items-center gap-1 cursor-pointer"
-              >
-                <Copy className="w-4 h-4" />
-                복사
-              </Button>
-            </p>
-            {remainingTime !== null && remainingTime > 0 ? (
-              <p className="absolute bottom-9 left-6 label2-regular text-gray-500">
-                참여 코드 만료 D-{formatSecondsToHHMMSS(remainingTime)}
+            <div className="flex items-center justify-between">
+              <p className="subtitle1-bold">참여 코드</p>
+              <div className="flex items-center gap-2">
+                <span className="subtitle2-regular">{joinCode}</span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleCopy}
+                  className="flex items-center gap-1 cursor-pointer"
+                >
+                  <Copy className="w-4 h-4" />
+                  복사
+                </Button>
+              </div>
+            </div>
+
+            {remainingTime !== null && (
+              <p className="label2-regular text-gray-500">
+                참여 코드 만료 D-{formatSecondsToHHMMSS(Math.max(remainingTime, 0))}
               </p>
-            ) : (
-              <Button
-                variant="link"
-                onClick={handleRefresh}
-                className="absolute bottom-6 left-3 cursor-pointer label2-regular text-gray-500"
-              >
-                <RefreshCw className="w-3 h-3" /> 참여 코드가 만료되었습니다. 여기를 눌러 참여코드를
-                재발급 해주세요!
-              </Button>
             )}
           </>
         ) : (
@@ -86,8 +100,17 @@ const ProjectJoinCodeViewModalContent = ({ projectId }: ProjectJoinCodeViewModal
         )}
       </div>
 
-      <DialogFooter>
-        <Button onClick={resetModal} className="bg-boost-blue hover:bg-boost-hover cursor-pointer">
+      <DialogFooter className="flex w-full !justify-between gap-2">
+        <Button
+          variant="link"
+          onClick={handleRefresh}
+          disabled={isCreating}
+          className="cursor-pointer flex items-center gap-1 !pl-0 text-gray-600"
+        >
+          <RefreshCw className="w-4 h-4" />
+          {isCreating ? '참여 코드 재발급 중...' : '참여 코드 재발급'}
+        </Button>
+        <Button variant="defaultBoost" onClick={resetModal}>
           닫기
         </Button>
       </DialogFooter>

--- a/src/features/project/components/ProjectMemberItem.tsx
+++ b/src/features/project/components/ProjectMemberItem.tsx
@@ -7,7 +7,7 @@ import { useProjectStore } from '@/features/project/store/useProjectStore';
 import { ROLES } from '@/features/project/constants/projectConstants';
 import { useModal } from '@/shared/hooks/useModal';
 import ProjectKickMemberModalContent from '@/features/project/components/ProjectManageModal/ProjectKickMemberModalContent';
-import { useAuthStore } from '@/features/auth/store/authStore';
+import { useAuthStore } from '@/features/auth/store/useAuthStore';
 
 interface ProjectMemberItemProps {
   member: MemberWithBoosting;

--- a/src/features/project/hooks/useCreateJoinCodeMutation.ts
+++ b/src/features/project/hooks/useCreateJoinCodeMutation.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { projectMembershipApi } from '@/features/project/api/projectMembershipApi';
+import type { JoinCodeResponse } from '@/features/project/types/projectTypes';
+
+export const useCreateJoinCodeMutation = (projectId: string) => {
+  const queryClient = useQueryClient();
+
+  return useMutation<JoinCodeResponse, Error, void>({
+    mutationFn: () => {
+      return projectMembershipApi.createJoinCode(projectId);
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData(['joinCode', projectId], (prev) => ({
+        ...(prev ?? {}),
+        joinCode: data.joinCode,
+        expiresAt: data.expiresAt,
+      }));
+    },
+    onError: (error) => {
+      console.error('참여 코드 생성 실패:', error);
+    },
+  });
+};

--- a/src/features/settings/components/AlarmSettingCard.tsx
+++ b/src/features/settings/components/AlarmSettingCard.tsx
@@ -62,7 +62,7 @@ const AlarmSettingCard = () => {
       <div className="px-1 mb-4">
         <Button
           className="w-50 h-10 text-white bg-boost-blue/90 hover:bg-boost-blue cursor-pointer disabled:opacity-50"
-          onClick={() => navigate(ROUTE_PATH.ALARM_SETUP)}
+          onClick={() => navigate(ROUTE_PATH.ALARM_SETUP, { state: { from: ROUTE_PATH.SETTINGS } })}
         >
           새로운 기기 등록하기
         </Button>

--- a/src/features/settings/components/AlarmSettingCard.tsx
+++ b/src/features/settings/components/AlarmSettingCard.tsx
@@ -38,7 +38,6 @@ const AlarmSettingCard = () => {
 
     const initialState: Record<string, boolean> = {};
     projectsData.forEach((project) => {
-      console.log(project);
       initialState[project.id] = project.isNotificationEnabled ?? false;
     });
 

--- a/src/features/settings/hooks/useDeleteAccountMutation.ts
+++ b/src/features/settings/hooks/useDeleteAccountMutation.ts
@@ -1,6 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 import { settingsApi } from '@/features/settings/api/settingsApi';
-import { useAuthStore } from '@/features/auth/store/authStore';
+import { useAuthStore } from '@/features/auth/store/useAuthStore';
 import toast from 'react-hot-toast';
 
 export const useDeleteAccountMutation = () => {

--- a/src/features/settings/hooks/useMyInfoQuery.ts
+++ b/src/features/settings/hooks/useMyInfoQuery.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { settingsApi } from '@/features/settings/api/settingsApi';
-import { useAuthStore } from '@/features/auth/store/authStore';
+import { useAuthStore } from '@/features/auth/store/useAuthStore';
 
 export const useMyInfoQuery = () => {
   const accessToken = useAuthStore((state) => state.accessToken);

--- a/src/features/settings/hooks/useUpdateAvatarMutation.ts
+++ b/src/features/settings/hooks/useUpdateAvatarMutation.ts
@@ -41,8 +41,6 @@ export const useUpdateAvatarMutation = () => {
     },
 
     onSuccess: (updated) => {
-      toast.success('아바타가 변경되었습니다!');
-
       if (user) {
         setAuth({
           user: {

--- a/src/features/settings/hooks/useUpdateAvatarMutation.ts
+++ b/src/features/settings/hooks/useUpdateAvatarMutation.ts
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { settingsApi } from '@/features/settings/api/settingsApi';
 import toast from 'react-hot-toast';
 import type { MyInfoResponse } from '@/features/settings/types/settingsTypes';
-import { useAuthStore } from '@/features/auth/store/authStore';
+import { useAuthStore } from '@/features/auth/store/useAuthStore';
 import type { AvatarInfo } from '@/features/user/types/userTypes';
 
 interface UpdateAvatarPayload {

--- a/src/features/tag/utils/tagUtils.ts
+++ b/src/features/tag/utils/tagUtils.ts
@@ -51,9 +51,15 @@ export function getColorStyleForTag(tag: Tag | string, withBorder = false): TagC
 
 export function generateTags(task: TaskDetail | TaskListItem): TagList {
   const tags: TagList = [];
+  const hasReviewers = task.requiredReviewerCount && task.requiredReviewerCount > 0;
 
-  if (task.requiredReviewerCount && task.requiredReviewerCount > 0)
-    tags.push({ tagId: 'system-review', name: '검토필요' });
+  if ('status' in task && hasReviewers) {
+    if (task.status === 'DONE') {
+      tags.push({ tagId: 'system-review-done', name: '검토완료' });
+    } else {
+      tags.push({ tagId: 'system-review', name: '검토필요' });
+    }
+  }
 
   if (task.tags) tags.push(...task.tags);
 

--- a/src/features/task-detail/components/CommentSection/AuthorAvatar.tsx
+++ b/src/features/task-detail/components/CommentSection/AuthorAvatar.tsx
@@ -1,0 +1,63 @@
+import { Avatar, AvatarFallback, AvatarImage } from '@/shared/components/shadcn/avatar';
+import { User } from 'lucide-react';
+import BOO from '@/shared/assets/images/boost/boo.png';
+import type { PersonaType } from '@/features/comment/constants/personaConstants';
+import { getAvatarSrc } from '@/features/avatar-picker/utils/avatarUtils';
+
+interface AuthorAvatarProps {
+  persona?: PersonaType; // 'BOO' | null
+  isAnonymous: boolean;
+  avatar?: string | null;
+  backgroundColor?: string | null;
+  name?: string | null;
+}
+
+export const AuthorAvatar = ({
+  persona,
+  isAnonymous,
+  avatar,
+  backgroundColor,
+  name,
+}: AuthorAvatarProps) => {
+  const isBooPersona = persona === 'BOO';
+  const effectiveAnonymous = isBooPersona ? true : isAnonymous;
+
+  // ✅ BOO 페르소나 (CommentItem 기준 스타일 그대로)
+  if (isBooPersona) {
+    return (
+      <Avatar className="flex items-center justify-center h-8 w-8 shrink-0 shadow-xs bg-boost-yellow">
+        <AvatarImage className="w-6 h-6" src={BOO} alt="BOO" />
+        <AvatarFallback>BOO</AvatarFallback>
+      </Avatar>
+    );
+  }
+
+  // ✅ 완전 익명
+  if (effectiveAnonymous) {
+    return (
+      <Avatar className="flex items-center justify-center h-8 w-8 shrink-0 shadow-xs bg-gray-500">
+        <User className="w-4 h-4 text-white" />
+      </Avatar>
+    );
+  }
+
+  // ✅ 일반 사용자
+  return (
+    <Avatar
+      className="flex items-center justify-center h-8 w-8 shrink-0 shadow-xs text-white text-xs"
+      style={{
+        backgroundColor: backgroundColor ?? undefined,
+      }}
+    >
+      {avatar ? (
+        <AvatarImage
+          src={getAvatarSrc({ avatar })}
+          alt={name || 'avatar'}
+          className="h-7 w-7 object-cover rounded-full"
+        />
+      ) : (
+        <AvatarFallback>{name?.charAt(0).toUpperCase()}</AvatarFallback>
+      )}
+    </Avatar>
+  );
+};

--- a/src/features/task-detail/components/CommentSection/AuthorAvatar.tsx
+++ b/src/features/task-detail/components/CommentSection/AuthorAvatar.tsx
@@ -22,7 +22,6 @@ export const AuthorAvatar = ({
   const isBooPersona = persona === 'BOO';
   const effectiveAnonymous = isBooPersona ? true : isAnonymous;
 
-  // ✅ BOO 페르소나 (CommentItem 기준 스타일 그대로)
   if (isBooPersona) {
     return (
       <Avatar className="flex items-center justify-center h-8 w-8 shrink-0 shadow-xs bg-boost-yellow">
@@ -32,7 +31,6 @@ export const AuthorAvatar = ({
     );
   }
 
-  // ✅ 완전 익명
   if (effectiveAnonymous) {
     return (
       <Avatar className="flex items-center justify-center h-8 w-8 shrink-0 shadow-xs bg-gray-500">
@@ -41,7 +39,6 @@ export const AuthorAvatar = ({
     );
   }
 
-  // ✅ 일반 사용자
   return (
     <Avatar
       className="flex items-center justify-center h-8 w-8 shrink-0 shadow-xs text-white text-xs"

--- a/src/features/task-detail/components/CommentSection/CommentItem.tsx
+++ b/src/features/task-detail/components/CommentSection/CommentItem.tsx
@@ -6,6 +6,7 @@ import type { FileInfo } from '@/features/task-detail/types/taskDetailType';
 import { useAuthStore } from '@/features/auth/store/authStore';
 import { CommentActionsMenu } from '@/features/task-detail/components/CommentSection/CommentActionsMenu';
 import { AuthorAvatar } from './AuthorAvatar';
+import { useTaskDetailStore } from '@/features/task-detail/store/useTaskDetailStore';
 
 interface CommentItemProps {
   comment: CommentUIType;
@@ -23,12 +24,16 @@ const CommentItem = forwardRef<HTMLDivElement, CommentItemProps>(
     const isAnonymous = comment.isAnonymous;
     const { user } = useAuthStore();
     const isAuthor = user?.id === comment.authorInfo.memberId;
-
+    const { setActivePinCommentId, clearCurrentPin } = useTaskDetailStore();
     return (
       <div ref={ref} className="flex py-3">
         <div className="flex-1">
           <div
-            onClick={() => onSelectPin?.(comment.fileInfo ?? null)}
+            onClick={() => {
+              onSelectPin?.(comment.fileInfo ?? null);
+              setActivePinCommentId(comment.commentId);
+              clearCurrentPin();
+            }}
             className={cn(
               'rounded-xl px-4 py-3 shadow-sm relative transition-all duration-200 border bg-gray-200 border-gray-200',
 
@@ -36,7 +41,10 @@ const CommentItem = forwardRef<HTMLDivElement, CommentItemProps>(
 
               isSelected && 'border border-boost-blue/60 bg-boost-blue/10',
 
-              isPinHighlighted && !isEditing && 'border-1 border-boost-yellow bg-boost-yellow/10',
+              isPinHighlighted &&
+                !isEditing &&
+                comment.fileInfo &&
+                'border-1 border-boost-yellow bg-boost-yellow/10',
             )}
           >
             <div className="flex items-center justify-between">

--- a/src/features/task-detail/components/CommentSection/CommentItem.tsx
+++ b/src/features/task-detail/components/CommentSection/CommentItem.tsx
@@ -5,13 +5,16 @@ import type { FileInfo } from '@/features/task-detail/types/taskDetailType';
 import { useAuthStore } from '@/features/auth/store/authStore';
 import { CommentActionsMenu } from '@/features/task-detail/components/CommentSection/CommentActionsMenu';
 import { AuthorAvatar } from '@/features/task-detail/components/CommentSection/AuthorAvatar';
+
 interface CommentItemProps {
   comment: CommentUIType;
   onEdit?: (comment: CommentUIType) => void;
   onDelete?: (commentId: string) => void;
   onSelectPin?: (fileInfo: FileInfo | null) => void;
+
   isEditing?: boolean;
-  isHighlighted?: boolean;
+  isSelected?: boolean;
+  isPinHighlighted?: boolean;
 }
 
 const CommentItem = ({
@@ -20,7 +23,8 @@ const CommentItem = ({
   onDelete,
   onSelectPin,
   isEditing,
-  isHighlighted,
+  isSelected,
+  isPinHighlighted,
 }: CommentItemProps) => {
   const isAnonymous = comment.isAnonymous;
   const { user } = useAuthStore();
@@ -33,8 +37,12 @@ const CommentItem = ({
           onClick={() => onSelectPin?.(comment.fileInfo ?? null)}
           className={cn(
             'rounded-xl px-4 py-3 shadow-sm relative transition-all duration-200 border bg-gray-200 border-gray-200',
+
             isEditing && 'bg-boost-blue/5 border-boost-blue/40',
-            isHighlighted && 'border-2 border-boost-blue bg-boost-blue/10',
+
+            isSelected && 'border border-boost-blue/60 bg-boost-blue/10',
+
+            isPinHighlighted && 'border-1 border-boost-yellow bg-boost-yellow/10',
           )}
         >
           <div className="flex items-center justify-between">

--- a/src/features/task-detail/components/CommentSection/CommentItem.tsx
+++ b/src/features/task-detail/components/CommentSection/CommentItem.tsx
@@ -38,7 +38,7 @@ const CommentItem = forwardRef<HTMLDivElement, CommentItemProps>(
               'rounded-xl px-4 py-3 shadow-sm relative transition-all duration-200 border bg-gray-200 border-gray-200',
 
               isEditing && 'bg-boost-blue/5 border-boost-blue/40',
-
+              comment.fileInfo && 'cursor-pointer',
               isSelected && 'border border-boost-blue/60 bg-boost-blue/10',
 
               isPinHighlighted &&

--- a/src/features/task-detail/components/CommentSection/CommentItem.tsx
+++ b/src/features/task-detail/components/CommentSection/CommentItem.tsx
@@ -4,9 +4,9 @@ import { cn } from '@/shared/lib/utils';
 import type { CommentUIType } from '@/features/comment/types/commentTypes';
 import { getAvatarSrc } from '@/features/avatar-picker/utils/avatarUtils';
 import type { FileInfo } from '@/features/task-detail/types/taskDetailType';
-import { useAuthStore } from '@/features/auth/store/authStore';
+import { useAuthStore } from '@/features/auth/store/useAuthStore';
 import { CommentActionsMenu } from '@/features/task-detail/components/CommentSection/CommentActionsMenu';
-import BOO from '@/shared/assets/images/boost/boo.png'
+import BOO from '@/shared/assets/images/boost/boo.png';
 interface CommentItemProps {
   comment: CommentUIType;
   onEdit?: (comment: CommentUIType) => void;

--- a/src/features/task-detail/components/CommentSection/CommentItem.tsx
+++ b/src/features/task-detail/components/CommentSection/CommentItem.tsx
@@ -1,12 +1,10 @@
-import { Avatar, AvatarFallback, AvatarImage } from '@/shared/components/shadcn/avatar';
-import { Pin, User } from 'lucide-react';
+import { Pin } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
 import type { CommentUIType } from '@/features/comment/types/commentTypes';
-import { getAvatarSrc } from '@/features/avatar-picker/utils/avatarUtils';
 import type { FileInfo } from '@/features/task-detail/types/taskDetailType';
 import { useAuthStore } from '@/features/auth/store/authStore';
 import { CommentActionsMenu } from '@/features/task-detail/components/CommentSection/CommentActionsMenu';
-import BOO from '@/shared/assets/images/boost/boo.png'
+import { AuthorAvatar } from '@/features/task-detail/components/CommentSection/AuthorAvatar';
 interface CommentItemProps {
   comment: CommentUIType;
   onEdit?: (comment: CommentUIType) => void;
@@ -27,47 +25,6 @@ const CommentItem = ({
   const isAnonymous = comment.isAnonymous;
   const { user } = useAuthStore();
   const isAuthor = user?.id === comment.authorInfo.memberId;
-  const isBooPersona = comment.persona === 'BOO';
-
-  const effectiveAnonymous = isBooPersona ? true : comment.isAnonymous;
-
-  const renderAvatar = () => {
-    if (isBooPersona) {
-      return (
-        <Avatar className="flex items-center justify-center h-8 w-8 shrink-0 shadow-xs bg-boost-yellow">
-          <AvatarImage className="w-6 h-6" src={BOO} alt="BOO" />
-          <AvatarFallback>BOO</AvatarFallback>
-        </Avatar>
-      );
-    }
-
-    if (effectiveAnonymous) {
-      return (
-        <Avatar className="flex items-center justify-center h-8 w-8 shrink-0 shadow-xs bg-gray-500">
-          <User className="w-4 h-4 text-white" />
-        </Avatar>
-      );
-    }
-
-    return (
-      <Avatar
-        className="flex items-center justify-center h-8 w-8 shrink-0 shadow-xs text-white text-xs"
-        style={{
-          backgroundColor: comment.authorInfo.backgroundColor,
-        }}
-      >
-        {comment.authorInfo.avatar ? (
-          <AvatarImage
-            src={getAvatarSrc(comment.authorInfo)}
-            alt={comment.authorInfo.name}
-            className="h-7 w-7 object-cover rounded-full"
-          />
-        ) : (
-          <AvatarFallback>{comment.authorInfo.name?.charAt(0).toUpperCase()}</AvatarFallback>
-        )}
-      </Avatar>
-    );
-  };
 
   return (
     <div className="flex py-3">
@@ -82,7 +39,13 @@ const CommentItem = ({
         >
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2 pb-3">
-              {renderAvatar()}
+              <AuthorAvatar
+                persona={comment.persona}
+                isAnonymous={comment.isAnonymous}
+                avatar={comment.authorInfo.avatar}
+                backgroundColor={comment.authorInfo.backgroundColor}
+                name={comment.authorInfo.name}
+              />
               <span className="label1-bold text-sm text-gray-800">
                 {isAnonymous ? '익명' : comment.authorInfo.name}
               </span>

--- a/src/features/task-detail/components/CommentSection/CommentItem.tsx
+++ b/src/features/task-detail/components/CommentSection/CommentItem.tsx
@@ -1,10 +1,11 @@
+import { forwardRef } from 'react';
 import { Pin } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
 import type { CommentUIType } from '@/features/comment/types/commentTypes';
 import type { FileInfo } from '@/features/task-detail/types/taskDetailType';
 import { useAuthStore } from '@/features/auth/store/authStore';
 import { CommentActionsMenu } from '@/features/task-detail/components/CommentSection/CommentActionsMenu';
-import { AuthorAvatar } from '@/features/task-detail/components/CommentSection/AuthorAvatar';
+import { AuthorAvatar } from './AuthorAvatar';
 
 interface CommentItemProps {
   comment: CommentUIType;
@@ -17,65 +18,59 @@ interface CommentItemProps {
   isPinHighlighted?: boolean;
 }
 
-const CommentItem = ({
-  comment,
-  onEdit,
-  onDelete,
-  onSelectPin,
-  isEditing,
-  isSelected,
-  isPinHighlighted,
-}: CommentItemProps) => {
-  const isAnonymous = comment.isAnonymous;
-  const { user } = useAuthStore();
-  const isAuthor = user?.id === comment.authorInfo.memberId;
+const CommentItem = forwardRef<HTMLDivElement, CommentItemProps>(
+  ({ comment, onEdit, onDelete, onSelectPin, isEditing, isSelected, isPinHighlighted }, ref) => {
+    const isAnonymous = comment.isAnonymous;
+    const { user } = useAuthStore();
+    const isAuthor = user?.id === comment.authorInfo.memberId;
 
-  return (
-    <div className="flex py-3">
-      <div className="flex-1">
-        <div
-          onClick={() => onSelectPin?.(comment.fileInfo ?? null)}
-          className={cn(
-            'rounded-xl px-4 py-3 shadow-sm relative transition-all duration-200 border bg-gray-200 border-gray-200',
+    return (
+      <div ref={ref} className="flex py-3">
+        <div className="flex-1">
+          <div
+            onClick={() => onSelectPin?.(comment.fileInfo ?? null)}
+            className={cn(
+              'rounded-xl px-4 py-3 shadow-sm relative transition-all duration-200 border bg-gray-200 border-gray-200',
 
-            isEditing && 'bg-boost-blue/5 border-boost-blue/40',
+              isEditing && 'bg-boost-blue/5 border-boost-blue/40',
 
-            isSelected && 'border border-boost-blue/60 bg-boost-blue/10',
+              isSelected && 'border border-boost-blue/60 bg-boost-blue/10',
 
-            isPinHighlighted && 'border-1 border-boost-yellow bg-boost-yellow/10',
-          )}
-        >
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2 pb-3">
-              <AuthorAvatar
-                persona={comment.persona}
-                isAnonymous={comment.isAnonymous}
-                avatar={comment.authorInfo.avatar}
-                backgroundColor={comment.authorInfo.backgroundColor}
-                name={comment.authorInfo.name}
-              />
-              <span className="label1-bold text-sm text-gray-800">
-                {isAnonymous ? '익명' : comment.authorInfo.name}
-              </span>
-              {comment.isPinned && <Pin className="h-3.5 w-3.5 text-boost-blue cursor-pointer" />}
-            </div>
-
-            <div className="flex items-center gap-1">
-              <span className="text-xs text-gray-500">{comment.timeAgo}</span>
-              {isAuthor && (
-                <CommentActionsMenu
-                  onEdit={() => onEdit?.(comment)}
-                  onDelete={() => onDelete?.(comment.commentId)}
+              isPinHighlighted && !isEditing && 'border-1 border-boost-yellow bg-boost-yellow/10',
+            )}
+          >
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2 pb-3">
+                <AuthorAvatar
+                  persona={comment.persona}
+                  isAnonymous={comment.isAnonymous}
+                  avatar={comment.authorInfo.avatar}
+                  backgroundColor={comment.authorInfo.backgroundColor}
+                  name={comment.authorInfo.name}
                 />
-              )}
-            </div>
-          </div>
+                <span className="label1-bold text-sm text-gray-800">
+                  {isAnonymous ? '익명' : comment.authorInfo.name}
+                </span>
+                {comment.isPinned && <Pin className="h-3.5 w-3.5 text-boost-blue" />}
+              </div>
 
-          <p className="mt-1 text-sm text-gray-800">{comment.content}</p>
+              <div className="flex items-center gap-1">
+                <span className="text-xs text-gray-500">{comment.timeAgo}</span>
+                {isAuthor && (
+                  <CommentActionsMenu
+                    onEdit={() => onEdit?.(comment)}
+                    onDelete={() => onDelete?.(comment.commentId)}
+                  />
+                )}
+              </div>
+            </div>
+
+            <p className="mt-1 text-sm text-gray-800">{comment.content}</p>
+          </div>
         </div>
       </div>
-    </div>
-  );
-};
+    );
+  },
+);
 
 export default CommentItem;

--- a/src/features/task-detail/components/CommentSection/CommentList.tsx
+++ b/src/features/task-detail/components/CommentSection/CommentList.tsx
@@ -12,7 +12,6 @@ interface CommentListProps {
 
 const CommentList = ({ comments, onDelete, onSelectPin }: CommentListProps) => {
   const scrollRef = useRef<HTMLDivElement>(null);
-
   const pinnedRef = useRef<HTMLDivElement | null>(null);
 
   const { activePinCommentId, selectedCommentId, editingComment, setEditingComment } =
@@ -29,6 +28,12 @@ const CommentList = ({ comments, onDelete, onSelectPin }: CommentListProps) => {
     }
   }, [activePinCommentId]);
 
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [comments]);
+  
   return (
     <div ref={scrollRef} className="px-4 flex-1 overflow-y-auto pb-35">
       {comments.map((comment) => (

--- a/src/features/task-detail/components/CommentSection/CommentList.tsx
+++ b/src/features/task-detail/components/CommentSection/CommentList.tsx
@@ -12,24 +12,33 @@ interface CommentListProps {
 
 const CommentList = ({ comments, onDelete, onSelectPin }: CommentListProps) => {
   const scrollRef = useRef<HTMLDivElement>(null);
-  const { setEditingComment, editingComment, selectedCommentId, activePinCommentId } =
+
+  const pinnedRef = useRef<HTMLDivElement | null>(null);
+
+  const { activePinCommentId, selectedCommentId, editingComment, setEditingComment } =
     useTaskDetailStore();
 
   useEffect(() => {
-    if (scrollRef.current) {
-      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    if (!activePinCommentId) return;
+
+    if (pinnedRef.current) {
+      pinnedRef.current.scrollIntoView({
+        behavior: 'smooth',
+        block: 'start',
+      });
     }
-  }, [comments]);
+  }, [activePinCommentId]);
 
   return (
     <div ref={scrollRef} className="px-4 flex-1 overflow-y-auto pb-35">
       {comments.map((comment) => (
         <CommentItem
           key={comment.commentId}
+          ref={comment.commentId === activePinCommentId ? pinnedRef : null}
           comment={comment}
           isEditing={editingComment?.id === comment.commentId}
           isSelected={comment.commentId === selectedCommentId}
-          isPinHighlighted={comment.commentId === activePinCommentId}
+          isPinHighlighted={comment.commentId === activePinCommentId && !editingComment}
           onEdit={() =>
             setEditingComment({
               id: comment.commentId,

--- a/src/features/task-detail/components/CommentSection/CommentList.tsx
+++ b/src/features/task-detail/components/CommentSection/CommentList.tsx
@@ -12,7 +12,8 @@ interface CommentListProps {
 
 const CommentList = ({ comments, onDelete, onSelectPin }: CommentListProps) => {
   const scrollRef = useRef<HTMLDivElement>(null);
-  const { setEditingComment, editingComment, selectedCommentId } = useTaskDetailStore();
+  const { setEditingComment, editingComment, selectedCommentId, activePinCommentId } =
+    useTaskDetailStore();
 
   useEffect(() => {
     if (scrollRef.current) {
@@ -27,7 +28,8 @@ const CommentList = ({ comments, onDelete, onSelectPin }: CommentListProps) => {
           key={comment.commentId}
           comment={comment}
           isEditing={editingComment?.id === comment.commentId}
-          isHighlighted={comment.commentId === selectedCommentId} // ✅ 강조 상태 전달
+          isSelected={comment.commentId === selectedCommentId}
+          isPinHighlighted={comment.commentId === activePinCommentId}
           onEdit={() =>
             setEditingComment({
               id: comment.commentId,

--- a/src/features/task-detail/components/CommentSection/CommentSection.tsx
+++ b/src/features/task-detail/components/CommentSection/CommentSection.tsx
@@ -29,7 +29,7 @@ const CommentSection = ({ projectId, taskId, onCommentsFetched }: CommentSection
   const { data: task } = useTaskDetailQuery(projectId, taskId);
   const { pins, clearCurrentPin, currentPin, persona } = useTaskDetailStore();
   const { commentSelect } = useCommentSelect();
-  /** 핀 클릭 시 PDF 위치 이동 */
+  /** 댓글의 핀 아이콘 클릭 시 PDF 위치 이동 */
   const handlePinClick = (fileInfo: FileInfo | null) => {
     if (!fileInfo || !task?.files) return;
     commentSelect(fileInfo, task.files, pins);

--- a/src/features/task-detail/components/CommentSection/CommentSection.tsx
+++ b/src/features/task-detail/components/CommentSection/CommentSection.tsx
@@ -29,7 +29,6 @@ const CommentSection = ({ projectId, taskId, onCommentsFetched }: CommentSection
   const { data: task } = useTaskDetailQuery(projectId, taskId);
   const { pins, clearCurrentPin, currentPin, persona } = useTaskDetailStore();
   const { commentSelect } = useCommentSelect();
-
   /** 핀 클릭 시 PDF 위치 이동 */
   const handlePinClick = (fileInfo: FileInfo | null) => {
     if (!fileInfo || !task?.files) return;

--- a/src/features/task-detail/components/PdfViewer/PdfHeaderBar.tsx
+++ b/src/features/task-detail/components/PdfViewer/PdfHeaderBar.tsx
@@ -1,15 +1,19 @@
+import { usePdfStore } from '@/features/task-detail/store/usePdfStore';
 import { useTaskDetailStore } from '@/features/task-detail/store/useTaskDetailStore';
 
 const PdfHeaderBar = () => {
-  const { selectedFile, togglePdf } = useTaskDetailStore();
-
+  const { clearFileState, selectedFile} = useTaskDetailStore();
+const {resetPdf}= usePdfStore()
   return (
     <div className="w-full h-12 flex items-center justify-between bg-white border-b border-gray-400 px-4">
       <span className="text-sm font-medium truncate max-w-[70%]">
         {selectedFile?.fileName ?? 'PDF 문서'}
       </span>
       <button
-        onClick={() => togglePdf(false)}
+        onClick={() => {
+          clearFileState();
+          resetPdf()
+        }}
         className="text-sm bg-gray-700 hover:bg-gray-800 text-white px-3 py-1 rounded-md transition"
       >
         ← 뒤로가기

--- a/src/features/task-detail/components/PdfViewer/PdfOverlay.tsx
+++ b/src/features/task-detail/components/PdfViewer/PdfOverlay.tsx
@@ -1,7 +1,6 @@
 import { PinAvatar } from './PinAvatar';
 import { useAuthStore } from '@/features/auth/store/authStore';
 import { useTaskDetailStore } from '@/features/task-detail/store/useTaskDetailStore';
-import { v4 as uuidv4 } from 'uuid';
 import type { PinWithAuthor } from '@/features/task-detail/types/taskDetailType';
 import type { PageSize } from '@/features/task-detail/types/pdfTypes';
 interface OverlayProps {
@@ -24,7 +23,7 @@ const Overlay = ({ pageNumber, zoom, pageSize, onClick }: OverlayProps) => {
           const top = 100 - ((pin.fileY ?? 0) / pageSize.height) * 100;
           return (
             <PinAvatar
-              key={uuidv4()}
+              key={pin.commentId}
               persona={pin.persona}
               isAnonymous={!!pin.isAnonymous}
               avatar={pin.author?.avatar}

--- a/src/features/task-detail/components/PdfViewer/PdfOverlay.tsx
+++ b/src/features/task-detail/components/PdfViewer/PdfOverlay.tsx
@@ -17,31 +17,31 @@ interface OverlayProps {
 const Overlay = ({ pageNumber, zoom, pageSize, onClick }: OverlayProps) => {
   const { pins, currentPin, selectedFile, setSelectedCommentId } = useTaskDetailStore();
   const pinList = pins as PinWithAuthor[];
-  const { user } = useAuthStore();
+  const user = useAuthStore((state) => state.user);
 
   return (
     <div className="absolute top-0 left-0 w-full h-full z-10" onClick={onClick}>
       {pinList
-        .filter((m) => m.fileId === selectedFile?.fileId && m.filePage === pageNumber)
-        .map((m) => {
-          const left = (m.fileX ? m.fileX / pageSize.width : 0) * 100;
-          const top = 100 - (m.fileY ? m.fileY / pageSize.height : 0) * 100;
-          const isAnonymous = m.isAnonymous;
+        .filter((pin) => pin.fileId === selectedFile?.fileId && pin.filePage === pageNumber)
+        .map((pin) => {
+          const left = (pin.fileX ? pin.fileX / pageSize.width : 0) * 100;
+          const top = 100 - (pin.fileY ? pin.fileY / pageSize.height : 0) * 100;
+          const isAnonymous = pin.isAnonymous;
 
           return (
             <div
               key={uuidv4()}
               onClick={(e) => {
                 e.stopPropagation();
-                if (m.commentId) setSelectedCommentId(m.commentId);
+                if (pin.commentId) setSelectedCommentId(pin.commentId);
               }}
               className={cn(
                 'flex items-center justify-center absolute w-7 h-7 rounded-[50%_50%_50%_0] -rotate-45 border-2 shadow-md overflow-hidden cursor-pointer select-none transition-all duration-200',
                 isAnonymous ? 'bg-gray-500 border-gray-500' : '',
               )}
               style={{
-                backgroundColor: !isAnonymous ? m.author?.backgroundColor : undefined,
-                borderColor: !isAnonymous ? m.author?.backgroundColor : undefined,
+                backgroundColor: !isAnonymous ? pin.author?.backgroundColor : undefined,
+                borderColor: !isAnonymous ? pin.author?.backgroundColor : undefined,
                 left: `${left}%`,
                 top: `${top}%`,
                 transform: `translate(50%, -120%) scale(${zoom})`,
@@ -51,21 +51,23 @@ const Overlay = ({ pageNumber, zoom, pageSize, onClick }: OverlayProps) => {
                 <User className="text-white w-3.5 h-3.5 rotate-[45deg]" />
               ) : (
                 <img
-                  src={getAvatarSrc({ avatar: m.author?.avatar })}
-                  style={{ backgroundColor: m.author?.backgroundColor }}
-                  alt={m.author?.name ?? 'avatar'}
+                  src={getAvatarSrc({ avatar: pin.author?.avatar })}
+                  style={{ backgroundColor: pin.author?.backgroundColor }}
+                  alt={pin.author?.name ?? 'avatar'}
                   className="w-6 h-6 object-cover rotate-[45deg]"
                 />
               )}
             </div>
           );
         })}
+
       {currentPin &&
         currentPin.filePage === pageNumber &&
         (() => {
           const left = (currentPin.fileX ? currentPin.fileX / pageSize.width : 0) * 100;
           const top = 100 - (currentPin.fileY ? currentPin.fileY / pageSize.height : 0) * 100;
           const isAnonymous = user?.isAnonymous;
+
           return (
             <div
               className={cn(

--- a/src/features/task-detail/components/PdfViewer/PdfOverlay.tsx
+++ b/src/features/task-detail/components/PdfViewer/PdfOverlay.tsx
@@ -10,7 +10,7 @@ interface OverlayProps {
   onClick: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
 }
 const Overlay = ({ pageNumber, zoom, pageSize, onClick }: OverlayProps) => {
-  const { pins, currentPin, setActivePinCommentId, selectedFile, persona, editingComment } =
+  const { pins, clearCurrentPin,activePinCommentId,currentPin, setActivePinCommentId, selectedFile, persona, editingComment } =
     useTaskDetailStore();
   const pinList = pins as PinWithAuthor[];
   const user = useAuthStore((state) => state.user);
@@ -32,11 +32,13 @@ const Overlay = ({ pageNumber, zoom, pageSize, onClick }: OverlayProps) => {
               name={pin.author?.name}
               zoom={zoom}
               left={left}
+              isHighlighted={pin.commentId === activePinCommentId}
               top={top}
               onClick={() => {
                 if (pin.commentId) {
                   if (editingComment) return;
                   setActivePinCommentId(pin.commentId);
+                  clearCurrentPin()
                 }
               }}
             />

--- a/src/features/task-detail/components/PdfViewer/PdfOverlay.tsx
+++ b/src/features/task-detail/components/PdfViewer/PdfOverlay.tsx
@@ -10,7 +10,8 @@ interface OverlayProps {
   onClick: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
 }
 const Overlay = ({ pageNumber, zoom, pageSize, onClick }: OverlayProps) => {
-  const { pins, currentPin, selectedFile, persona, setSelectedCommentId } = useTaskDetailStore();
+  const { pins, currentPin, setActivePinCommentId, selectedFile, persona, editingComment } =
+    useTaskDetailStore();
   const pinList = pins as PinWithAuthor[];
   const user = useAuthStore((state) => state.user);
 
@@ -33,7 +34,10 @@ const Overlay = ({ pageNumber, zoom, pageSize, onClick }: OverlayProps) => {
               left={left}
               top={top}
               onClick={() => {
-                if (pin.commentId) setSelectedCommentId(pin.commentId);
+                if (pin.commentId) {
+                  if (editingComment) return;
+                  setActivePinCommentId(pin.commentId);
+                }
               }}
             />
           );

--- a/src/features/task-detail/components/PdfViewer/PdfOverlay.tsx
+++ b/src/features/task-detail/components/PdfViewer/PdfOverlay.tsx
@@ -10,8 +10,17 @@ interface OverlayProps {
   onClick: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
 }
 const Overlay = ({ pageNumber, zoom, pageSize, onClick }: OverlayProps) => {
-  const { pins, clearCurrentPin,activePinCommentId,currentPin, setActivePinCommentId, selectedFile, persona, editingComment } =
-    useTaskDetailStore();
+  const {
+    pins,
+    isAnonymous,
+    clearCurrentPin,
+    activePinCommentId,
+    currentPin,
+    setActivePinCommentId,
+    selectedFile,
+    persona,
+    editingComment,
+  } = useTaskDetailStore();
   const pinList = pins as PinWithAuthor[];
   const user = useAuthStore((state) => state.user);
 
@@ -38,7 +47,7 @@ const Overlay = ({ pageNumber, zoom, pageSize, onClick }: OverlayProps) => {
                 if (pin.commentId) {
                   if (editingComment) return;
                   setActivePinCommentId(pin.commentId);
-                  clearCurrentPin()
+                  clearCurrentPin();
                 }
               }}
             />
@@ -56,7 +65,7 @@ const Overlay = ({ pageNumber, zoom, pageSize, onClick }: OverlayProps) => {
           return (
             <PinAvatar
               persona={persona}
-              isAnonymous={user?.isAnonymous ?? false}
+              isAnonymous={isAnonymous ?? false}
               avatar={user?.avatar}
               backgroundColor={user?.backgroundColor}
               name={user?.name}

--- a/src/features/task-detail/components/PdfViewer/PdfOverlay.tsx
+++ b/src/features/task-detail/components/PdfViewer/PdfOverlay.tsx
@@ -1,5 +1,5 @@
 import { PinAvatar } from './PinAvatar';
-import { useAuthStore } from '@/features/auth/store/authStore';
+import { useAuthStore } from '@/features/auth/store/useAuthStore';
 import { useTaskDetailStore } from '@/features/task-detail/store/useTaskDetailStore';
 import type { PinWithAuthor } from '@/features/task-detail/types/taskDetailType';
 import type { PageSize } from '@/features/task-detail/types/pdfTypes';

--- a/src/features/task-detail/components/PdfViewer/PdfOverlay.tsx
+++ b/src/features/task-detail/components/PdfViewer/PdfOverlay.tsx
@@ -1,6 +1,6 @@
 import type { PageSize } from '@/features/task-detail/types/pdfTypes';
 import { getAvatarSrc } from '@/features/avatar-picker/utils/avatarUtils';
-import { useAuthStore } from '@/features/auth/store/authStore';
+import { useAuthStore } from '@/features/auth/store/useAuthStore';
 import type { PinWithAuthor } from '@/features/task-detail/types/taskDetailType';
 import { useTaskDetailStore } from '@/features/task-detail/store/useTaskDetailStore';
 import { User } from 'lucide-react';

--- a/src/features/task-detail/components/PdfViewer/PdfViewer.tsx
+++ b/src/features/task-detail/components/PdfViewer/PdfViewer.tsx
@@ -14,10 +14,15 @@ pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/b
 
 const PDFViewer = () => {
   const { pageNumber, zoom, position, isDragging, pdfDocument, pageSize } = usePdfStore();
-  const { onMouseDown, onMouseMove, onMouseUp } = usePdfDrag();
+  const { onMouseDown, onMouseMove, onMouseUp, mouseMoved } = usePdfDrag();
   const { onDocumentLoadSuccess, setPdfDocument } = usePdfDocument(pdfDocument, pageNumber);
   const { handleOverlayClick } = usePdfPinInteraction(pageNumber, pageSize);
   const { clearFileState, selectedFile } = useTaskDetailStore();
+
+  const handleOverlayClickWithDragCheck = (e: React.MouseEvent) => {
+    if (mouseMoved.current) return;
+    handleOverlayClick(e);
+  };
 
   return (
     <div className="flex flex-col w-full h-full bg-gray-300">
@@ -57,7 +62,7 @@ const PDFViewer = () => {
             pageNumber={pageNumber}
             zoom={zoom}
             pageSize={pageSize}
-            onClick={handleOverlayClick}
+            onClick={handleOverlayClickWithDragCheck}
           />
         </div>
       </div>

--- a/src/features/task-detail/components/PdfViewer/PdfViewer.tsx
+++ b/src/features/task-detail/components/PdfViewer/PdfViewer.tsx
@@ -9,6 +9,7 @@ import { usePdfDrag } from '@/features/task-detail/hooks/usePdfDrag';
 import { useTaskDetailStore } from '@/features/task-detail/store/useTaskDetailStore';
 import { usePdfPinInteraction } from '@/features/task-detail/hooks/usePdfPinInteraction';
 import { usePdfDocument } from '@/features/task-detail/hooks/usePdfDocument';
+import PdfHeaderBar from '@/features/task-detail/components/PdfViewer/PdfHeaderBar';
 
 pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.mjs`;
 
@@ -17,19 +18,11 @@ const PDFViewer = () => {
   const { onMouseDown, onMouseMove, onMouseUp } = usePdfDrag();
   const { onDocumentLoadSuccess, setPdfDocument } = usePdfDocument(pdfDocument, pageNumber);
   const { handleOverlayClick } = usePdfPinInteraction(pageNumber, pageSize);
-  const { clearFileState, selectedFile } = useTaskDetailStore();
+  const { selectedFile } = useTaskDetailStore();
 
   return (
     <div className="flex flex-col w-full h-full bg-gray-300">
-      <div className="w-full h-12 flex items-center justify-between te bg-white border-b-gray-400 xt-white px-4">
-        <span className="text-sm">{selectedFile?.fileName}</span>
-        <button
-          onClick={() => clearFileState()}
-          className="text-sm bg-gray-700 hover:bg-gray-800 text-white px-3 py-1 rounded-md transition"
-        >
-          ← 뒤로가기
-        </button>
-      </div>
+      <PdfHeaderBar/>
       <div className="flex-1 flex justify-center items-center overflow-hidden">
         <div
           className={cn('relative bg-white', isDragging ? 'cursor-grabbing' : 'cursor-grab')}

--- a/src/features/task-detail/components/PdfViewer/PinAvatar.tsx
+++ b/src/features/task-detail/components/PdfViewer/PinAvatar.tsx
@@ -1,7 +1,7 @@
 import { Avatar, AvatarFallback, AvatarImage } from '@/shared/components/shadcn/avatar';
 import { User } from 'lucide-react';
 import BOO from '@/shared/assets/images/boost/boo.png';
-import type { PersonaType } from '@/features/comment/constants/personaConstants';
+import { PERSONA, type PersonaType } from '@/features/comment/constants/personaConstants';
 import { cn } from '@/shared/lib/utils';
 import { getAvatarSrc } from '@/features/avatar-picker/utils/avatarUtils';
 
@@ -34,7 +34,7 @@ export const PinAvatar = ({
   isHighlighted,
   onClick,
 }: PinAvatarProps) => {
-  const isBoo = persona === 'BOO';
+  const isBoo = persona === PERSONA.BOO
   return (
     <div
       onClick={(e) => {

--- a/src/features/task-detail/components/PdfViewer/PinAvatar.tsx
+++ b/src/features/task-detail/components/PdfViewer/PinAvatar.tsx
@@ -13,8 +13,8 @@ interface PinAvatarProps {
   name?: string | null;
 
   zoom: number;
-  left: number; 
-  top: number; 
+  left: number;
+  top: number;
 
   className?: string;
   onClick?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
@@ -60,7 +60,7 @@ export const PinAvatar = ({
       <div className="flex items-center justify-center w-full h-full rotate-[45deg]">
         {isBoo ? (
           <img src={BOO} alt="BOO" className="w-5 h-5 object-contain" />
-        ) : !isBoo&&isAnonymous ? (
+        ) : !isBoo && isAnonymous ? (
           <User className="text-white w-4 h-4" />
         ) : (
           <Avatar className="bg-transparent w-full h-full flex items-center justify-center">

--- a/src/features/task-detail/components/PdfViewer/PinAvatar.tsx
+++ b/src/features/task-detail/components/PdfViewer/PinAvatar.tsx
@@ -1,0 +1,85 @@
+// PinAvatar.tsx
+import { Avatar, AvatarFallback, AvatarImage } from '@/shared/components/shadcn/avatar';
+import { User } from 'lucide-react';
+import BOO from '@/shared/assets/images/boost/boo.png';
+import type { PersonaType } from '@/features/comment/constants/personaConstants';
+import { cn } from '@/shared/lib/utils';
+import { getAvatarSrc } from '@/features/avatar-picker/utils/avatarUtils';
+
+interface PinAvatarProps {
+  persona?: PersonaType;
+  isAnonymous: boolean;
+  avatar?: string | null;
+  backgroundColor?: string | null;
+  name?: string | null;
+
+  zoom: number;
+  left: number; // % 위치
+  top: number; // % 위치
+
+  className?: string;
+  onClick?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
+}
+
+export const PinAvatar = ({
+  persona,
+  isAnonymous,
+  avatar,
+  backgroundColor,
+  name,
+  zoom,
+  left,
+  top,
+  className,
+  onClick,
+}: PinAvatarProps) => {
+  const isBoo = persona === 'BOO';
+  return (
+    <div
+      onClick={(e) => {
+        e.stopPropagation();
+        onClick?.(e);
+      }}
+      className={cn(
+        'absolute w-8 h-8 rounded-[50%_50%_50%_0] -rotate-45 border-2 shadow-md overflow-hidden cursor-pointer select-none transition-all duration-200',
+        // BOO → 디자인 토큰
+        isBoo && 'bg-boost-yellow border-boost-yellow',
+        // 익명 → 회색
+        !isBoo && isAnonymous && 'bg-gray-500 border-gray-500',
+        className,
+      )}
+      style={{
+        ...(!isBoo && !isAnonymous
+          ? {
+              backgroundColor: backgroundColor ?? undefined,
+              borderColor: backgroundColor ?? undefined,
+            }
+          : {}),
+        left: `${left}%`,
+        top: `${top}%`,
+        transform: `translate(50%, -120%) scale(${zoom})`,
+      }}
+    >
+      {/* 내부 컨테이너: 회전 되돌리기 */}
+      <div className="flex items-center justify-center w-full h-full rotate-[45deg]">
+        {isBoo ? (
+          <img src={BOO} alt="BOO" className="w-5 h-5 object-contain" />
+        ) : !isBoo&&isAnonymous ? (
+          <User className="text-white w-4 h-4" />
+        ) : (
+          <Avatar className="bg-transparent w-full h-full flex items-center justify-center">
+            {avatar ? (
+              <AvatarImage
+                src={getAvatarSrc({ avatar })}
+                alt={name || 'avatar'}
+                className="w-6 h-6 object-cover rounded-full"
+              />
+            ) : (
+              <AvatarFallback className="text-xs">{name?.charAt(0)?.toUpperCase()}</AvatarFallback>
+            )}
+          </Avatar>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/features/task-detail/components/PdfViewer/PinAvatar.tsx
+++ b/src/features/task-detail/components/PdfViewer/PinAvatar.tsx
@@ -1,4 +1,3 @@
-// PinAvatar.tsx
 import { Avatar, AvatarFallback, AvatarImage } from '@/shared/components/shadcn/avatar';
 import { User } from 'lucide-react';
 import BOO from '@/shared/assets/images/boost/boo.png';
@@ -14,8 +13,8 @@ interface PinAvatarProps {
   name?: string | null;
 
   zoom: number;
-  left: number; // % 위치
-  top: number; // % 위치
+  left: number; 
+  top: number; 
 
   className?: string;
   onClick?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
@@ -41,10 +40,8 @@ export const PinAvatar = ({
         onClick?.(e);
       }}
       className={cn(
-        'absolute w-8 h-8 rounded-[50%_50%_50%_0] -rotate-45 border-2 shadow-md overflow-hidden cursor-pointer select-none transition-all duration-200',
-        // BOO → 디자인 토큰
+        'absolute w-8 h-8 rounded-[50%_50%_50%_0] -rotate-45 border-2 shadow-md overflow-hidden cursor-pointer select-none transition-all duration-200 z-50',
         isBoo && 'bg-boost-yellow border-boost-yellow',
-        // 익명 → 회색
         !isBoo && isAnonymous && 'bg-gray-500 border-gray-500',
         className,
       )}
@@ -60,7 +57,6 @@ export const PinAvatar = ({
         transform: `translate(50%, -120%) scale(${zoom})`,
       }}
     >
-      {/* 내부 컨테이너: 회전 되돌리기 */}
       <div className="flex items-center justify-center w-full h-full rotate-[45deg]">
         {isBoo ? (
           <img src={BOO} alt="BOO" className="w-5 h-5 object-contain" />

--- a/src/features/task-detail/components/PdfViewer/PinAvatar.tsx
+++ b/src/features/task-detail/components/PdfViewer/PinAvatar.tsx
@@ -15,6 +15,7 @@ interface PinAvatarProps {
   zoom: number;
   left: number;
   top: number;
+  isHighlighted?: boolean;
 
   className?: string;
   onClick?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
@@ -30,6 +31,7 @@ export const PinAvatar = ({
   left,
   top,
   className,
+  isHighlighted,
   onClick,
 }: PinAvatarProps) => {
   const isBoo = persona === 'BOO';
@@ -43,6 +45,8 @@ export const PinAvatar = ({
         'absolute w-8 h-8 rounded-[50%_50%_50%_0] -rotate-45 border-2 shadow-md overflow-hidden cursor-pointer select-none transition-all duration-200 z-50',
         isBoo && 'bg-boost-yellow border-boost-yellow',
         !isBoo && isAnonymous && 'bg-gray-500 border-gray-500',
+
+        isHighlighted && ' shadow-[0_0_15px_rgba(255,193,7,0.9)] scale-[1.18]',
         className,
       )}
       style={{

--- a/src/features/task-detail/components/TaskDetailContent/TaskDetailContent.tsx
+++ b/src/features/task-detail/components/TaskDetailContent/TaskDetailContent.tsx
@@ -1,7 +1,7 @@
 import { useNavigate, useParams } from 'react-router-dom';
 import { ROUTES } from '@/app/routes/Router';
 import type { TaskDetail } from '@/features/task/types/taskTypes';
-import { useAuthStore } from '@/features/auth/store/authStore';
+import { useAuthStore } from '@/features/auth/store/useAuthStore';
 import { useDeleteTaskMutation } from '@/features/task/hooks/useDeleteTaskMutation';
 import { useModal } from '@/shared/hooks/useModal';
 import StatusInfo from '@/features/task-detail/components/TaskDetailContent/StatusInfo';

--- a/src/features/task-detail/components/TaskDetailTopTab/TaskDetailTopTab.tsx
+++ b/src/features/task-detail/components/TaskDetailTopTab/TaskDetailTopTab.tsx
@@ -1,6 +1,6 @@
 import { useParams } from 'react-router-dom';
 import { cn } from '@/shared/lib/utils';
-import { useAuthStore } from '@/features/auth/store/authStore';
+import { useAuthStore } from '@/features/auth/store/useAuthStore';
 import { useTaskDetailStore } from '@/features/task-detail/store/useTaskDetailStore';
 import { AssigneeActionButton } from '@/features/task-detail/components/TaskDetailTopTab/AssigneeActionButton';
 import { ReviewerActionButton } from '@/features/task-detail/components/TaskDetailTopTab/ReviewerActionButton';

--- a/src/features/task-detail/components/TaskDetailTopTab/TaskDetailTopTab.tsx
+++ b/src/features/task-detail/components/TaskDetailTopTab/TaskDetailTopTab.tsx
@@ -9,6 +9,7 @@ import { useReviewerTask } from '@/features/task-detail/hooks/useReviewerTask';
 import type { TaskDetail } from '@/features/task/types/taskTypes';
 import { useAiTransformStore } from '@/features/ai-transform/store/useAiTransformStore';
 import BackButton from '@/shared/components/ui/BackButton';
+import { usePdfStore } from '@/features/task-detail/store/usePdfStore';
 
 interface TaskDetailTopTabProps {
   task: TaskDetail;
@@ -19,7 +20,7 @@ const TaskDetailTopTab = ({ task }: TaskDetailTopTabProps) => {
   const currentUser = useAuthStore((state) => state.user);
   const { projectId } = useParams<{ projectId: string }>();
   const resetAiComment = useAiTransformStore((state) => state.reset);
-
+const {resetPdf} = usePdfStore()
   const isAssignee = task.assignees.some((a) => a.id === currentUser?.id);
 
   const assigneeTask = useAssigneeTask({
@@ -46,6 +47,7 @@ const TaskDetailTopTab = ({ task }: TaskDetailTopTabProps) => {
           onBack={() => {
             resetAll();
             resetAiComment();
+            resetPdf()
           }}
         />
 

--- a/src/features/task-detail/hooks/usePdfPinInteraction.ts
+++ b/src/features/task-detail/hooks/usePdfPinInteraction.ts
@@ -7,7 +7,7 @@ import { useAuthStore } from '@/features/auth/store/authStore';
 export const usePdfPinInteraction = (pageNumber: number, pageSize: PageSize) => {
   const mouseMoved = useRef(false);
   const { user } = useAuthStore();
-  const { clearCurrentPin, currentPin, setCurrentPin, selectedFile, isAnonymous } =
+  const { clearCurrentPin, persona, currentPin, setCurrentPin, selectedFile, isAnonymous } =
     useTaskDetailStore();
 
   const handleOverlayClick = (e: React.MouseEvent) => {
@@ -43,6 +43,7 @@ export const usePdfPinInteraction = (pageNumber: number, pageSize: PageSize) => 
         backgroundColor: user?.backgroundColor ?? '#CCCCCC',
       },
       isAnonymous: isAnonymous,
+      persona: persona,
     };
 
     setCurrentPin(newPin);

--- a/src/features/task-detail/hooks/usePdfPinInteraction.ts
+++ b/src/features/task-detail/hooks/usePdfPinInteraction.ts
@@ -2,7 +2,7 @@ import { useRef } from 'react';
 import type { PinWithAuthor } from '@/features/task-detail/types/taskDetailType';
 import { useTaskDetailStore } from '@/features/task-detail/store/useTaskDetailStore';
 import type { PageSize } from '@/features/task-detail/types/pdfTypes'; // width, height 타입
-import { useAuthStore } from '@/features/auth/store/authStore';
+import { useAuthStore } from '@/features/auth/store/useAuthStore';
 
 export const usePdfPinInteraction = (pageNumber: number, pageSize: PageSize) => {
   const mouseMoved = useRef(false);

--- a/src/features/task-detail/store/usePdfStore.ts
+++ b/src/features/task-detail/store/usePdfStore.ts
@@ -30,8 +30,19 @@ interface PdfState {
   setPageSize: (size: PageSize) => void;
   updatePageSize: (pageNumber: number) => Promise<void>;
   setPageNumber: (page: number) => void;
+  resetPdf: () => void;
 }
-
+const initialState = {
+  numPages: 0,
+  pageNumber: 1,
+  zoom: 1,
+  position: { x: 0, y: 0 },
+  isDragging: false,
+  start: { x: 0, y: 0 },
+  markers: [],
+  pdfDocument: null,
+  pageSize: { width: A4.WIDTH, height: A4.HEIGHT },
+};
 export const usePdfStore = create<PdfState>((set, get) => ({
   numPages: 0,
   pageNumber: 1,
@@ -70,5 +81,6 @@ export const usePdfStore = create<PdfState>((set, get) => ({
         console.error('에러 : 페이지 크기 가져오기 실패', error);
       }
     }
-  },
+  },  resetPdf: () => set(initialState),
+
 }));

--- a/src/features/task-detail/store/useTaskDetailStore.ts
+++ b/src/features/task-detail/store/useTaskDetailStore.ts
@@ -16,7 +16,10 @@ interface TaskDetailState {
   isPdfOpen: boolean;
   isEditingPin: boolean;
   isAnonymous: boolean;
+
   selectedCommentId: string | null;
+  activePinCommentId: string | null;
+
   editingComment: EditingCommentState | null;
   persona: PersonaType;
 
@@ -27,7 +30,10 @@ interface TaskDetailState {
   togglePdf: (open: boolean) => void;
   setIsEditingPin: (val: boolean) => void;
   setIsAnonymous: (val: boolean) => void;
+
   setSelectedCommentId: (id: string | null) => void;
+  setActivePinCommentId: (id: string | null) => void;
+
   setEditingComment: (comment: EditingCommentState | null) => void;
 
   clearCurrentPin: () => void;
@@ -42,7 +48,10 @@ const initialState = {
   isPdfOpen: false,
   isEditingPin: false,
   isAnonymous: false,
+
   selectedCommentId: null,
+  activePinCommentId: null,
+
   editingComment: null,
   persona: null,
 };
@@ -50,16 +59,24 @@ const initialState = {
 export const useTaskDetailStore = create<TaskDetailState>((set) => ({
   ...initialState,
 
+  setPersona: (persona) => set({ persona }),
   setSelectedFile: (selectedFile) => set({ selectedFile }),
   setCurrentPin: (currentPin) => set({ currentPin }),
   setPins: (pins) => set({ pins }),
   togglePdf: (isPdfOpen) => set({ isPdfOpen }),
   setIsEditingPin: (val) => set({ isEditingPin: val }),
   setIsAnonymous: (val) => set({ isAnonymous: val }),
-  setSelectedCommentId: (id) => set({ selectedCommentId: id }),
-  setEditingComment: (comment) => set({ editingComment: comment }),
 
+  setSelectedCommentId: (id) => set({ selectedCommentId: id }),
+  setActivePinCommentId: (id) => set({ activePinCommentId: id }),
+
+  setEditingComment: (comment) =>
+    set((state) => ({
+      editingComment: comment,
+      activePinCommentId: comment ? null : state.activePinCommentId,
+    })),
   clearCurrentPin: () => set({ currentPin: null }),
+
   clearFileState: () =>
     set({
       selectedFile: null,
@@ -67,8 +84,10 @@ export const useTaskDetailStore = create<TaskDetailState>((set) => ({
       isPdfOpen: false,
       persona: null,
       isAnonymous: false,
+
+      activePinCommentId: null,
+      selectedCommentId: null,
     }),
 
   resetAll: () => set(initialState),
-  setPersona: (persona) => set({ persona }),
 }));

--- a/src/features/task-detail/types/taskDetailType.ts
+++ b/src/features/task-detail/types/taskDetailType.ts
@@ -1,3 +1,4 @@
+import type { PersonaType } from '@/features/comment/constants/personaConstants';
 import type { AuthorInfo } from '@/features/comment/types/commentTypes';
 
 export interface FileInfo {
@@ -18,5 +19,6 @@ export interface PinWithAuthor {
   author?: AuthorInfo;
   commentId?: string;
   isAnonymous?: boolean;
+  persona:PersonaType;
 }
 export type FileStatus = 'uploading' | 'success';

--- a/src/features/task-detail/types/taskDetailType.ts
+++ b/src/features/task-detail/types/taskDetailType.ts
@@ -19,6 +19,6 @@ export interface PinWithAuthor {
   author?: AuthorInfo;
   commentId?: string;
   isAnonymous?: boolean;
-  persona:PersonaType;
+  persona: PersonaType;
 }
 export type FileStatus = 'uploading' | 'success';

--- a/src/features/task/api/taskApi.ts
+++ b/src/features/task/api/taskApi.ts
@@ -18,7 +18,7 @@ export const taskApi = {
   fetchMyTasksByStatus: async (
     cursor?: string,
     status?: string,
-    limit = 8,
+    limit = 6,
     sortBy: SortBy = SORT_BY.CREATED_AT,
     direction: Direction = DIRECTION.ASC,
     search?: string,
@@ -34,7 +34,7 @@ export const taskApi = {
     projectId: string,
     cursor?: string,
     status?: string,
-    limit = 8,
+    limit = 6,
     sortBy: SortBy = SORT_BY.CREATED_AT,
     direction: Direction = DIRECTION.ASC,
     search?: string,
@@ -50,7 +50,7 @@ export const taskApi = {
     projectId: string,
     memberId: string,
     cursor?: string,
-    limit = 8,
+    limit = 6,
     search?: string,
   ): Promise<MemberTaskListResponse> => {
     const res = await api.get<MemberTaskListResponse>(

--- a/src/features/task/hooks/useCreateTaskForm.ts
+++ b/src/features/task/hooks/useCreateTaskForm.ts
@@ -1,6 +1,6 @@
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useState } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { createTaskSchema, type CreateTaskInput } from '@/features/task/schemas/taskSchema';
 import { useModal } from '@/shared/hooks/useModal';
 import { useProjectMembersQuery } from '@/features/project/hooks/useProjectMembersQuery';
@@ -13,14 +13,44 @@ export const useCreateTaskForm = (
   const { resetModal } = useModal();
   const [isLoading, setIsLoading] = useState(false);
   const projectData = useProjectStore((state) => state.projectData);
+  const { data: projectMembers = [] } = useProjectMembersQuery(initialProjectId);
+
+  const resolver = useMemo(() => {
+    return zodResolver(
+      createTaskSchema.superRefine((data, ctx) => {
+        const numAssignees = data.assignees?.length || 0;
+        const maxReviewers = projectMembers.length - numAssignees;
+
+        if (numAssignees === 0) {
+          ctx.addIssue({
+            code: 'custom',
+            message: '담당자를 먼저 지정해주세요.',
+            path: ['requiredReviewerCount'],
+          });
+        } else if (maxReviewers <= 0) {
+          ctx.addIssue({
+            code: 'custom',
+            message: '담당자로 모두 지정되어 검토 수를 지정할 수 없습니다. 0으로 설정해주세요.',
+            path: ['requiredReviewerCount'],
+          });
+        } else if (data.requiredReviewerCount! > maxReviewers) {
+          ctx.addIssue({
+            code: 'custom',
+            message: `검토 수는 담당자를 제외한 최대 ${maxReviewers}명까지 설정할 수 있습니다.`,
+            path: ['requiredReviewerCount'],
+          });
+        }
+      }),
+    );
+  }, [projectMembers]);
 
   const form = useForm<CreateTaskInput>({
-    resolver: zodResolver(createTaskSchema),
+    resolver,
     mode: 'onChange',
     defaultValues: {
       title: '',
       description: '',
-      requiredReviewerCount: projectData.defaultReviewerCount,
+      requiredReviewerCount: projectData.defaultReviewerCount ?? 0,
       assignees: [],
       dueDate: '',
       status: 'TODO',
@@ -30,8 +60,24 @@ export const useCreateTaskForm = (
     },
   });
 
-  const selectedProjectId = form.watch('projectId');
-  const { data: projectMembers = [] } = useProjectMembersQuery(selectedProjectId || '');
+  const assignees = form.watch('assignees');
+  const numAssignees = assignees?.length || 0;
+  const maxReviewers = Math.max(projectMembers.length - numAssignees, 0);
+
+  useEffect(() => {
+    if (projectMembers.length === 0) return;
+
+    const defaultCount = projectData.defaultReviewerCount ?? 0;
+    const safeCount = defaultCount > maxReviewers ? maxReviewers : defaultCount;
+
+    form.setValue('requiredReviewerCount', safeCount, { shouldValidate: true });
+  }, [projectMembers, maxReviewers, projectData.defaultReviewerCount, form]);
+
+  useEffect(() => {
+    if (numAssignees > 0 && maxReviewers <= 0) {
+      form.setValue('requiredReviewerCount', 0);
+    }
+  }, [numAssignees, maxReviewers, form]);
 
   const handleConfirm = form.handleSubmit(async (data) => {
     setIsLoading(true);

--- a/src/features/task/hooks/useCreateTaskForm.ts
+++ b/src/features/task/hooks/useCreateTaskForm.ts
@@ -19,7 +19,7 @@ export const useCreateTaskForm = (
     return zodResolver(
       createTaskSchema.superRefine((data, ctx) => {
         const numAssignees = data.assignees?.length || 0;
-        const maxReviewers = projectMembers.length - numAssignees;
+        const maxReviewers = Math.max(projectMembers.length - numAssignees, 0);
 
         if (numAssignees === 0) {
           ctx.addIssue({
@@ -27,7 +27,7 @@ export const useCreateTaskForm = (
             message: '담당자를 먼저 지정해주세요.',
             path: ['requiredReviewerCount'],
           });
-        } else if (maxReviewers <= 0) {
+        } else if (maxReviewers <= 0 && data.requiredReviewerCount! > 0) {
           ctx.addIssue({
             code: 'custom',
             message: '담당자로 모두 지정되어 검토 수를 지정할 수 없습니다. 0으로 설정해주세요.',

--- a/src/features/task/hooks/useInfiniteMyTasksByStatusQuery.ts
+++ b/src/features/task/hooks/useInfiniteMyTasksByStatusQuery.ts
@@ -19,7 +19,7 @@ export const useInfiniteMyTasksByStatusQuery = (
       taskApi.fetchMyTasksByStatus(
         typeof pageParam === 'string' ? pageParam : undefined,
         status,
-        10,
+        6,
         sortBy,
         direction,
         search,

--- a/src/features/task/hooks/useInfiniteProjectTasksByMemberQuery.ts
+++ b/src/features/task/hooks/useInfiniteProjectTasksByMemberQuery.ts
@@ -23,7 +23,7 @@ export const useInfiniteProjectTasksByMemberQuery = (
         projectId,
         memberId,
         typeof pageParam === 'string' ? pageParam : undefined,
-        10,
+        6,
         search,
       ),
     getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.nextCursor : undefined),

--- a/src/features/task/hooks/useInfiniteProjectTasksByStatusQuery.ts
+++ b/src/features/task/hooks/useInfiniteProjectTasksByStatusQuery.ts
@@ -21,7 +21,7 @@ export const useInfiniteProjectTasksByStatusQuery = (
         projectId,
         typeof pageParam === 'string' ? pageParam : undefined,
         status,
-        10,
+        6,
         sortBy,
         direction,
         search,

--- a/src/features/task/hooks/useUpdateTaskForm.ts
+++ b/src/features/task/hooks/useUpdateTaskForm.ts
@@ -1,6 +1,6 @@
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useState } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { updateTaskSchema, type UpdateTaskInput } from '@/features/task/schemas/taskSchema';
 import { useModal } from '@/shared/hooks/useModal';
 import { useProjectMembersQuery } from '@/features/project/hooks/useProjectMembersQuery';
@@ -14,11 +14,39 @@ export const useUpdateTaskForm = (
 ) => {
   const { resetModal } = useModal();
   const [isLoading, setIsLoading] = useState(false);
-
   const { data: projectMembers = [] } = useProjectMembersQuery(projectId);
 
+  const resolver = useMemo(() => {
+    return zodResolver(
+      updateTaskSchema.superRefine((data, ctx) => {
+        const numAssignees = data.assignees?.length || 0;
+        const maxReviewers = projectMembers.length - numAssignees;
+
+        if (numAssignees === 0) {
+          ctx.addIssue({
+            code: 'custom',
+            message: '담당자를 먼저 지정해주세요.',
+            path: ['requiredReviewerCount'],
+          });
+        } else if (maxReviewers <= 0) {
+          ctx.addIssue({
+            code: 'custom',
+            message: '담당자로 모두 지정되어 검토 수를 지정할 수 없습니다. 0으로 설정해주세요.',
+            path: ['requiredReviewerCount'],
+          });
+        } else if (data.requiredReviewerCount! > maxReviewers) {
+          ctx.addIssue({
+            code: 'custom',
+            message: `검토 수는 담당자를 제외한 최대 ${maxReviewers}명까지 설정할 수 있습니다.`,
+            path: ['requiredReviewerCount'],
+          });
+        }
+      }),
+    );
+  }, [projectMembers]);
+
   const form = useForm<UpdateTaskInput>({
-    resolver: zodResolver(updateTaskSchema),
+    resolver,
     mode: 'onChange',
     defaultValues: {
       title: task.title,
@@ -31,6 +59,25 @@ export const useUpdateTaskForm = (
       urgent: task.urgent ?? false,
     },
   });
+
+  const assignees = form.watch('assignees');
+  const numAssignees = assignees?.length || 0;
+  const maxReviewers = Math.max(projectMembers.length - numAssignees, 0);
+
+  useEffect(() => {
+    if (projectMembers.length === 0) return;
+
+    const currentValue = task.requiredReviewerCount ?? 0;
+    const safeCount = currentValue > maxReviewers ? maxReviewers : currentValue;
+
+    form.setValue('requiredReviewerCount', safeCount, { shouldValidate: true });
+  }, [projectMembers, maxReviewers, task.requiredReviewerCount, form]);
+
+  useEffect(() => {
+    if (numAssignees > 0 && maxReviewers <= 0) {
+      form.setValue('requiredReviewerCount', 0);
+    }
+  }, [numAssignees, maxReviewers, form]);
 
   const handleConfirm = form.handleSubmit(async (data) => {
     setIsLoading(true);

--- a/src/features/task/hooks/useUpdateTaskForm.ts
+++ b/src/features/task/hooks/useUpdateTaskForm.ts
@@ -20,7 +20,7 @@ export const useUpdateTaskForm = (
     return zodResolver(
       updateTaskSchema.superRefine((data, ctx) => {
         const numAssignees = data.assignees?.length || 0;
-        const maxReviewers = projectMembers.length - numAssignees;
+        const maxReviewers = Math.max(projectMembers.length - numAssignees, 0);
 
         if (numAssignees === 0) {
           ctx.addIssue({
@@ -28,7 +28,7 @@ export const useUpdateTaskForm = (
             message: '담당자를 먼저 지정해주세요.',
             path: ['requiredReviewerCount'],
           });
-        } else if (maxReviewers <= 0) {
+        } else if (maxReviewers <= 0 && data.requiredReviewerCount! > 0) {
           ctx.addIssue({
             code: 'custom',
             message: '담당자로 모두 지정되어 검토 수를 지정할 수 없습니다. 0으로 설정해주세요.',

--- a/src/features/user/types/userTypes.ts
+++ b/src/features/user/types/userTypes.ts
@@ -6,7 +6,6 @@ export interface User {
   notificationEnabled?: boolean;
   createdAt?: Date;
   updatedAt?: Date;
-  isAnonymous?: boolean;
 }
 
 export interface Member {

--- a/src/pages/AlarmPermissionPage.tsx
+++ b/src/pages/AlarmPermissionPage.tsx
@@ -75,7 +75,6 @@ const AlarmPermissionPage = () => {
     }
 
     if (isIOS && !isStandalone()) {
-      console.log('iOS Safari → connectPushSession 실행 안 함');
       return;
     }
 

--- a/src/pages/AlarmSetupPage.tsx
+++ b/src/pages/AlarmSetupPage.tsx
@@ -14,6 +14,7 @@ import { usePushSessionStatusQuery } from '@/features/webpush/hooks/usePushSessi
 import { WebPushStatus } from '@/features/webpush/types/pushApiTypes';
 import { useEnableServiceAlarmMutation } from '@/features/webpush/hooks/useEnableServiceAlarmMutation';
 import { Button } from '@/shared/components/shadcn/button';
+import InlineLoader from '@/shared/components/ui/loading/InlineLoader';
 
 const INTERVAL_MS = 30 * 10000;
 
@@ -80,14 +81,6 @@ const AlarmSetupPage = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  if (isPending && !data) {
-    return (
-      <div className="flex items-center justify-center h-screen text-gray-600 text-xl font-medium">
-        QR 코드 생성 중...
-      </div>
-    );
-  }
-
   const minutes = Math.floor(remainingTime / 60);
   const seconds = remainingTime % 60;
 
@@ -139,10 +132,16 @@ const AlarmSetupPage = () => {
 
         {/* QR 코드 */}
         <div className="p-4 shadow-md rounded-md bg-white mt-[-20px]">
-          {qrData ? (
+          {isPending && !data ? (
+            <p className="text-gray-500 text-sm text-center w-40 h-40 flex items-center justify-center">
+              <InlineLoader size={6} text="QR 코드 생성 중.." />
+            </p>
+          ) : qrData ? (
             <QRCodeSVG value={qrData} className="w-40 h-40" />
           ) : (
-            <p>QR 데이터를 불러오는 중입니다..</p>
+            <p className="text-gray-500 text-sm text-center w-40 h-40 flex items-center justify-center">
+              <InlineLoader size={6} text="QR 데이터 불러오는 중.." />
+            </p>
           )}
         </div>
 

--- a/src/pages/AlarmSetupPage.tsx
+++ b/src/pages/AlarmSetupPage.tsx
@@ -9,17 +9,21 @@ import { floatVariant, shakeVariant } from '@/shared/utils/animations/motionVari
 import { useCreatePushSessionMutation } from '@/features/webpush/hooks/useCreatePushSessionMutation';
 import toast from 'react-hot-toast';
 import { ROUTE_PATH } from '@/app/routes/Router';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { usePushSessionStatusQuery } from '@/features/webpush/hooks/usePushSessionStatusQuery';
 import { WebPushStatus } from '@/features/webpush/types/pushApiTypes';
 import { useEnableServiceAlarmMutation } from '@/features/webpush/hooks/useEnableServiceAlarmMutation';
-import BackButton from '@/shared/components/ui/BackButton';
+import { Button } from '@/shared/components/shadcn/button';
 
 const INTERVAL_MS = 30 * 10000;
 
 const AlarmSetupPage = () => {
   const navigate = useNavigate();
+  const location = useLocation();
+  const from = location.state?.from;
+
   const hasHandledStatus = useRef(false);
+
   const {
     mutate: createPushSession,
     data,
@@ -89,7 +93,6 @@ const AlarmSetupPage = () => {
 
   return (
     <div className="flex flex-row h-screen overflow-hidden">
-      <BackButton to={ROUTE_PATH.AVATAR} className="absolute top-8 left-8 z-50" />
       {/* 왼쪽 알림 예시 */}
       <section
         aria-label="Notification examples"
@@ -135,7 +138,7 @@ const AlarmSetupPage = () => {
         </div>
 
         {/* QR 코드 */}
-        <div className="p-4 shadow-md rounded-md bg-white">
+        <div className="p-4 shadow-md rounded-md bg-white mt-[-20px]">
           {qrData ? (
             <QRCodeSVG value={qrData} className="w-40 h-40" />
           ) : (
@@ -144,13 +147,25 @@ const AlarmSetupPage = () => {
         </div>
 
         {/* 남은 시간 */}
-        <p className="text-gray-500 font-semibold text-sm">
+        <p className="text-gray-700 font-semibold text-sm">
           QR 갱신까지 남은 시간: {minutes}:{seconds.toString().padStart(2, '0')}
         </p>
 
+        <Button
+          variant="link"
+          onClick={() => {
+            if (from === ROUTE_PATH.AVATAR) navigate(ROUTE_PATH.MY_TASK);
+            else if (from === ROUTE_PATH.SETTINGS) navigate(ROUTE_PATH.SETTINGS);
+            else navigate(ROUTE_PATH.MY_TASK);
+          }}
+          className="z-10 mt-[-20px] cursor-pointer text-gray-500"
+        >
+          다음에 할래요
+        </Button>
+
         {/* 중앙 이미지 */}
         <div aria-label="image" className="flex flex-col items-center">
-          <div aria-label="mockup" className="relative w-[640px] mt-1">
+          <div aria-label="mockup" className="relative w-[640px] mt-[-30px]">
             <motion.img
               src={AlarmBell}
               alt="alarm-bell"

--- a/src/pages/AvatarPickerPage.tsx
+++ b/src/pages/AvatarPickerPage.tsx
@@ -14,10 +14,10 @@ import type { User } from '@/features/user/types/userTypes';
 const AvatarSettingsPage = () => {
   const { selectedAvatarId, selectedBgColor } = useAvatarStore();
   const setAuth = useAuthStore((s) => s.setAuth);
-  const { mutate: saveAvatar } = useUpdateAvatarMutation();
+  const { mutateAsync: updateAvatar } = useUpdateAvatarMutation();
   const navigate = useNavigate();
 
-  const handleSave = () => {
+  const handleSave = async () => {
     if (!selectedBgColor) {
       toast.error('배경색을 선택해주세요!');
       return;
@@ -31,13 +31,15 @@ const AvatarSettingsPage = () => {
       backgroundColor: selectedBgColor,
     };
 
-    saveAvatar(avatarInfo, {
-      onSuccess: () => {
-        const updatedUser: User = { ...authUser, ...avatarInfo };
-        setAuth({ user: updatedUser });
-        navigate(ROUTE_PATH.ALARM_SETUP, { state: { from: ROUTE_PATH.AVATAR } });
-      },
-    });
+    try {
+      await updateAvatar(avatarInfo);
+      const updatedUser: User = { ...authUser, ...avatarInfo };
+      setAuth({ user: updatedUser });
+      navigate(ROUTE_PATH.ALARM_SETUP, { state: { from: ROUTE_PATH.AVATAR } });
+    } catch (error) {
+      console.log('아바타 업데이트 실패', error);
+      toast.error('아바타 업데이트에 실패했습니다 😢');
+    }
   };
 
   return (

--- a/src/pages/AvatarPickerPage.tsx
+++ b/src/pages/AvatarPickerPage.tsx
@@ -6,9 +6,10 @@ import AvatarSelector from '@/features/avatar-picker/components/AvatarSelector';
 import AvatarInfo from '@/features/avatar-picker/components/AvatarInfo';
 import AvatarBackgroundDecorations from '@/features/avatar-picker/components/AvatarBackgroundDecorations';
 import AvatarSaveBtn from '@/features/avatar-picker/components/AvatarSaveBtn';
-import { useAuthStore } from '@/features/auth/store/authStore';
+import { useAuthStore } from '@/features/auth/store/useAuthStore';
 import { useAvatarStore } from '@/features/avatar-picker/store/useAvatarStore';
 import { useUpdateAvatarMutation } from '@/features/settings/hooks/useUpdateAvatarMutation';
+import type { User } from '@/features/user/types/userTypes';
 
 const AvatarSettingsPage = () => {
   const { selectedAvatarId, selectedBgColor } = useAvatarStore();
@@ -22,6 +23,9 @@ const AvatarSettingsPage = () => {
       return;
     }
 
+    const authUser = useAuthStore.getState().user;
+    if (!authUser) return;
+
     const avatarInfo = {
       avatar: selectedAvatarId,
       backgroundColor: selectedBgColor,
@@ -29,8 +33,9 @@ const AvatarSettingsPage = () => {
 
     saveAvatar(avatarInfo, {
       onSuccess: () => {
+        const updatedUser: User = { ...authUser, ...avatarInfo };
+        setAuth({ user: updatedUser });
         navigate(ROUTE_PATH.ALARM_SETUP, { state: { from: ROUTE_PATH.AVATAR } });
-        setAuth({ user: avatarInfo });
       },
     });
   };

--- a/src/pages/AvatarPickerPage.tsx
+++ b/src/pages/AvatarPickerPage.tsx
@@ -29,7 +29,7 @@ const AvatarSettingsPage = () => {
 
     saveAvatar(avatarInfo, {
       onSuccess: () => {
-        navigate(ROUTE_PATH.ALARM_SETUP);
+        navigate(ROUTE_PATH.ALARM_SETUP, { state: { from: ROUTE_PATH.AVATAR } });
         setAuth({ user: avatarInfo });
       },
     });

--- a/src/pages/MyTaskPage.tsx
+++ b/src/pages/MyTaskPage.tsx
@@ -45,12 +45,12 @@ const MyTaskPage = () => {
         buttons: [
           {
             text: '프로젝트 생성',
-            styleClass: 'bg-boost-orange hover:bg-boost-orange-hover duration-300 subtitle2-bold',
+            variant: 'secondaryBoost',
             onClick: showCreateProjectModal,
           },
           {
             text: '프로젝트 참여',
-            styleClass: 'bg-boost-blue hover:bg-boost-blue-hover duration-300 subtitle2-bold',
+            variant: 'defaultBoost',
             onClick: showJoinProjectModal,
           },
         ],

--- a/src/pages/MyTaskPage.tsx
+++ b/src/pages/MyTaskPage.tsx
@@ -1,6 +1,6 @@
 import { useProjectsQuery } from '@/features/project/hooks/useProjectsQuery';
 import { useModal } from '@/shared/hooks/useModal';
-import { useAuthStore } from '@/features/auth/store/authStore';
+import { useAuthStore } from '@/features/auth/store/useAuthStore';
 import { useProjectsStore } from '@/features/project/store/useProjectsStore';
 import { useProjectModals } from '@/features/project/hooks/useProjectModals';
 import { useEffect, useRef } from 'react';

--- a/src/shared/api/authIntercepter.ts
+++ b/src/shared/api/authIntercepter.ts
@@ -1,6 +1,6 @@
 import axios, { type AxiosRequestConfig } from 'axios';
 import { handleUnauthorized } from '@/shared/api/errorHandler';
-import { useAuthStore } from '@/features/auth/store/authStore';
+import { useAuthStore } from '@/features/auth/store/useAuthStore';
 import { apiPublic } from '@/shared/api/axiosInstance';
 interface AxiosRequestConfigWithRetry extends AxiosRequestConfig {
   _retry?: boolean;

--- a/src/shared/api/authIntercepter.ts
+++ b/src/shared/api/authIntercepter.ts
@@ -11,7 +11,7 @@ export const handleUnauthorizedRequest = async (originalRequest: AxiosRequestCon
     const { data } = await apiPublic.post(`/auth/reissue`, {}, { withCredentials: true });
 
     const newAccessToken = data.accessToken;
-    useAuthStore.getState().setAuth({ token: newAccessToken });
+    useAuthStore.getState().setAuth({ accessToken: newAccessToken });
 
     if (!originalRequest.headers) originalRequest.headers = {};
     originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;

--- a/src/shared/api/axiosInstance.ts
+++ b/src/shared/api/axiosInstance.ts
@@ -1,4 +1,4 @@
-import { useAuthStore } from '@/features/auth/store/authStore';
+import { useAuthStore } from '@/features/auth/store/useAuthStore';
 import axios from 'axios';
 import { handleGeneralApiError } from '@/shared/api/errorHandler';
 import { handleUnauthorizedRequest } from '@/shared/api/authIntercepter';

--- a/src/shared/api/errorHandler.ts
+++ b/src/shared/api/errorHandler.ts
@@ -38,6 +38,10 @@ export const handleGeneralApiError = (error: AxiosError<ApiErrorResponse>) => {
       //500 에러일때 에러바운더리에 걸리게 함
       throw new ApiError(data?.message || '서버 에러가 발생했습니다. ', status, error);
 
+    case 413:
+      // 413 : API 훅에서 필요에 따라 처리
+      throw error;
+
     case 409:
       // 409 : API 훅에서 필요에 따라 처리
       throw error;
@@ -58,4 +62,3 @@ export const handleGeneralApiError = (error: AxiosError<ApiErrorResponse>) => {
       alert(data.message || '알 수 없는 오류가 발생했습니다.');
   }
 };
-//TODO: BE와 에러코드에 관한 논의 후 더 추가할 예정

--- a/src/shared/api/errorHandler.ts
+++ b/src/shared/api/errorHandler.ts
@@ -1,4 +1,4 @@
-import { useAuthStore } from '@/features/auth/store/authStore';
+import { useAuthStore } from '@/features/auth/store/useAuthStore';
 import type { AxiosError } from 'axios';
 
 export class ApiError extends Error {

--- a/src/shared/components/shadcn/button.tsx
+++ b/src/shared/components/shadcn/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/shared/lib/utils';
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium focus:ring-transparent transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {

--- a/src/shared/components/ui/loading/InlineLoader.tsx
+++ b/src/shared/components/ui/loading/InlineLoader.tsx
@@ -4,13 +4,15 @@ import { Loader2 } from 'lucide-react';
 interface InlineLoaderProps {
   size?: number;
   className?: string;
+  text?: string;
 }
 
-const InlineLoader = ({ size = 6, className = '' }: InlineLoaderProps) => {
+const InlineLoader = ({ size = 6, className = '', text }: InlineLoaderProps) => {
   const dimension = `w-${size} h-${size}`;
   return (
-    <div className={cn('flex justify-center py-4', className)}>
+    <div className={cn('flex flex-col items-center py-4', className)}>
       <Loader2 className={cn(dimension, 'animate-spin text-gray-500')} />
+      {text && <p className="text-gray-500 text-sm mt-2 text-center">{text}</p>}
     </div>
   );
 };

--- a/src/shared/components/ui/modal/ModalButtons.tsx
+++ b/src/shared/components/ui/modal/ModalButtons.tsx
@@ -31,6 +31,7 @@ export function ModalButtons({ buttons }: ModalButtonsProps) {
           onClick={() => handleClick(btn.onClick)}
           disabled={btn.disabled || isLoading}
           className={cn('flex-1', btn.styleClass)}
+          variant={btn.variant}
         >
           {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
           {btn.text}

--- a/src/shared/types/modalTypes.ts
+++ b/src/shared/types/modalTypes.ts
@@ -3,7 +3,17 @@ import type { ReactNode } from 'react';
 export type ModalButton = {
   text: string;
   onClick: () => void | Promise<void>;
-  variant?: 'default' | 'outline' | 'primary' | 'destructive';
+  variant?:
+    | 'link'
+    | 'default'
+    | 'defaultBoost'
+    | 'secondaryBoost'
+    | 'destructive'
+    | 'outline'
+    | 'secondary'
+    | 'ghost'
+    | null
+    | undefined;
   disabled?: boolean;
   styleClass?: string;
 };

--- a/src/widgets/AppSidebar.tsx
+++ b/src/widgets/AppSidebar.tsx
@@ -27,10 +27,10 @@ const AppSidebar = () => {
 
   return (
     <Sidebar variant="sidebar" className="border-0 border-gray-300" collapsible="icon">
-      <SidebarHeader className="flex-row text-center pt-4 pb-4 pl-3 pr-3 h-18 bg-white cursor-pointer">
+      <SidebarHeader className="flex-row text-center pt-4 pb-4 pl-3 pr-3 h-18 bg-white">
         <Avatar
           style={{ backgroundColor: user?.backgroundColor }}
-          className="flex justify-center items-center w-11 h-11"
+          className="flex justify-center items-center w-11 h-11 shadow-sm"
         >
           {user ? (
             <img

--- a/src/widgets/AppSidebar.tsx
+++ b/src/widgets/AppSidebar.tsx
@@ -13,7 +13,7 @@ import AppSidebarMenuItem from '@/features/sidebar/components/AppSidebarMenuItem
 import AppSidebarProjectMenuItem from '@/features/sidebar/components/AppSidebarProjectMenuItem';
 import AppSidebarAlarmMenuItem from '@/features/notifications/components/AppSidebarNotificationMenuItem';
 import { useLogoutMutation } from '@/features/auth/hooks/useLogoutMutation';
-import { useAuthStore } from '@/features/auth/store/authStore';
+import { useAuthStore } from '@/features/auth/store/useAuthStore';
 import { getAvatarSrc } from '@/features/avatar-picker/utils/avatarUtils';
 import { Avatar } from '@/shared/components/shadcn/avatar';
 


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약

- 배포 테스트 후 버그 수정 및 개선 작업 진행했습니다.

<br/>

### ✨ 작업 내용

- 페이지네이션 8 -> 6 수정
- 알림 목록 가로 스크롤 삭제 및 텍스트 잘림 해결
- 부스팅 점수 왕관 부여 오류 수정
- 알림 설정 페이지에서 뒤로가기 시 아바타 설정 페이지로 가는 문제 해결
- 알림 설정 페이지 QR 생성 시 화면 전체 깜빡 거리는 문제 해결
- 가입자가 아바타 설정 페이지로 이동하지 못하는 문제 해결
- authStore -> useAuthStore 로 인한 import 경로 수정
- updataAvatarMutation 후속 처리 async/await 적용
- 참여 코드 리프레시 버튼 추가
- 프로젝트 존재하지 않을 때 모달 UI 개선
- 할 일 드래그 앤 드랍 시 이동만 해도 상태가 변경되는 오류 해결
- 할 일 생성/수정 폼 유효성 및 기본값 처리 개선
- 할 일 완료되면 검토완료 태그로 변경
- PDF Viewer 드래그/클릭 구분 안 되는 문제 해결
- 사이드바 헤더 UI 개선
- 에러 핸들러에서 에러 코드 413 처리 분리
- [Test 필요] AI 댓글 변환 500 에러 재시도 로직 추가
- 할 일 생성/수정 폼 유효성 검사 오류 수정
- BOO 페르소나 적용하여 핀 댓글 + PDF 핀에도 아바타 적용되도록 함
- 핀 댓글 클릭했을 때 PDF 내 해당 핀 하이라이트 기능 추가
- 반대로 PDF 핀을  클릭했을 시 댓글 하이라이트 기능 추가

<br/>

### ❗ 참고 사항(선택)

- AI 재시도 요청 로직은 테스트해봐야할것같습니다.

<br/>

### #️⃣ 연관 이슈

- Close
#295 
#328
#302
#317
#315, #316
#300
#323
#324
#322
#325
#321
#326
#329
#331
#327
#332
#318
#305
#331
