### PR TITLE
✨ (#194) 메모 에디터에 변경 내용 판단 로직 추가

### DIFF
--- a/src/features/memo/components/MemoEditor/MemoEditor.tsx
+++ b/src/features/memo/components/MemoEditor/MemoEditor.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useCreateMemoMutation } from '@/features/memo/hooks/useCreateMemoMutation';
 import { useUpdateMemoMutation } from '@/features/memo/hooks/useUpdateMemoMutation';
@@ -8,6 +8,7 @@ import MemoEditorHeader from '@/features/memo/components/MemoEditor/MemoEditorHe
 import MemoEditorTitle from '@/features/memo/components/MemoEditor/MemoEditorTitle';
 import MemoEditorContent from '@/features/memo/components/MemoEditor/MemoEditorContent';
 import FullPageLoader from '@/shared/components/ui/loading/FullPageLoader';
+import { ROUTES } from '@/app/routes/Router';
 
 const MemoEditor = () => {
   const navigate = useNavigate();
@@ -21,6 +22,9 @@ const MemoEditor = () => {
   const updateMutation = useUpdateMemoMutation(projectId ?? '', memoId ?? '');
   const { showEmptyFieldsModal, showUnsavedChangesModal } = useMemoModals();
 
+  const [initialTitle, setInitialTitle] = useState('');
+  const [initialContent, setInitialContent] = useState('');
+
   const isEditMode = !!memoId;
 
   useEffect(() => {
@@ -28,7 +32,21 @@ const MemoEditor = () => {
 
     setTitle(memo.title);
     setContent(memo.content);
+
+    setInitialTitle(memo.title);
+    setInitialContent(memo.content);
   }, [memo, isEditMode]);
+
+  useEffect(() => {
+    if (!isEditMode) {
+      setInitialTitle('');
+      setInitialContent('');
+    }
+  }, [isEditMode]);
+
+  const hasUnsavedChanges = useMemo(() => {
+    return title !== initialTitle || content !== initialContent;
+  }, [title, content, initialTitle, initialContent]);
 
   if (!projectId) return <div className="p-4">프로젝트 ID를 찾을 수 없습니다.</div>;
 
@@ -40,11 +58,26 @@ const MemoEditor = () => {
       return;
     }
 
-    if (isEditMode) updateMutation.mutate({ title, content });
-    else createMutation.mutate({ title, content });
+    const mutation = isEditMode ? updateMutation : createMutation;
+
+    mutation.mutate(
+      { title, content },
+      {
+        onSuccess: () => {
+          setInitialTitle(title);
+          setInitialContent(content);
+        },
+      },
+    );
   };
 
-  const handleCancel = () => showUnsavedChangesModal(projectId, navigate);
+  const handleCancel = () => {
+    if (!hasUnsavedChanges) {
+      navigate(ROUTES.PROJECT_MEMO_LIST(projectId));
+      return;
+    }
+    showUnsavedChangesModal(projectId, navigate);
+  };
 
   return (
     <div className="flex flex-col h-full overflow-hidden bg-gray-200 border-t border-gray-300">


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약

- 메모 에디터에 변경 내용 판단 로직 추가

<br/>

### ✨ 작업 내용

- 기존에는 메모 편집 페이지에서 실제 변경 사항이 없는 경우에도 이탈 경고 모달이 노출되고 있었습니다.
- 메모 편집 페이지에서 변경 내용이 있을 경우에만 이탈 경고 모달을 띄워주도록 변경했습니다.
- 초기 메모 상태와 현재 입력 값을 비교하여 변경된 내용이 있을 경우에만 경고 모달이 노출되도록 했습니다.

<br/>

- [x] 수정 모드에서 변경 없이 취소될 경우 -> 바로 목록으로 이동
- [x] 수정 모드에서 내용 변경 후 취소할 경우 -> 이탈 경고 모달 노출
- [x] 새 메모 작성 시작 후 입력 없이 취소할 경우 -> 바로 목록으로 이동
- [x] 새 메모 작성 시작 및 입력 후 취소할 경우 -> 이탈 경고 모달 노출
- [x] 저장 성공 후 다시 취소할 경우 -> 경고 없이 이동

<br/>

### ❗ 참고 사항(선택)

- 기존 모달 컴포넌트 및 UI는 변경하지 않고 로직만 추가했습니다.
- 메모 페이지 관련 리팩터링 사항이 있다면 따로 이슈 생성 후 작업하겠습니다.

<br/>

### #️⃣ 연관 이슈

- Close #194 
