### PR TITLE
🐛 (#348) 나의 할 일에서 할 일 생성 시 담당자 설정 안 되는 문제 해결

### DIFF
--- a/src/features/task/hooks/form/useCreateTaskForm.ts
+++ b/src/features/task/hooks/form/useCreateTaskForm.ts
@@ -17,16 +17,8 @@ export const useCreateTaskForm = (
   const { resetModal } = useModal();
   const [isLoading, setIsLoading] = useState(false);
   const projectData = useProjectStore((state) => state.projectData);
-  const { data: projectMembers = [] } = useProjectMembersQuery(initialProjectId);
-
-  const resolver = useMemo(() => {
-    return zodResolver(
-      createTaskSchema.superRefine((data, ctx) => validateReviewerCount(data, ctx, projectMembers)),
-    );
-  }, [projectMembers]);
 
   const form = useForm<CreateTaskInput>({
-    resolver,
     mode: 'onChange',
     defaultValues: {
       projectId: initialProjectId,
@@ -40,6 +32,21 @@ export const useCreateTaskForm = (
       urgent: false,
     },
   });
+
+  const currentProjectId = form.watch('projectId');
+  const { data: projectMembers = [] } = useProjectMembersQuery(
+    currentProjectId || initialProjectId,
+  );
+
+  const resolver = useMemo(() => {
+    return zodResolver(
+      createTaskSchema.superRefine((data, ctx) => validateReviewerCount(data, ctx, projectMembers)),
+    );
+  }, [projectMembers]);
+
+  useEffect(() => {
+    form.control._options.resolver = resolver;
+  }, [resolver, form]);
 
   const assignees = form.watch('assignees');
   const numAssignees = assignees?.length || 0;
@@ -64,7 +71,7 @@ export const useCreateTaskForm = (
     setIsLoading(true);
     try {
       const assigneeIds = data.assignees
-        .map((name) => projectMembers.find((m) => m.name === name)?.id)
+        .map((name) => projectMembers.find((m) => m.name === name || m.id === name)?.id)
         .filter((id): id is string => !!id);
 
       const payload: CreateTaskInput = {


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약

- 나의 할 일 페이지에서 할 일 생성 시, 담당자 설정이 안 되는 문제가 있어 이를 해결했습니다.

<br/>

### ✨ 작업 내용

- 담당자 설정 오류는 데이터의 흐름이 사용자의 입력을 실시간으로 따라가지 못해서 발생한 문제였습니다.
- 프로젝트 페이지에서는 문제 없이 잘 되나, 나의 할 일 페이지에서만 담당자 설정에 문제가 있었습니다.
- 할 일 생성 모달에서 담당자를 설정하더라도 서버에 전송되는 payload에 담당자가 빈 배열로 전송되고 있었습니다.
   ```
   assignees : [] 
   description : "ㅁㄴㅇ" 
   dueDate : "2026-01-14" 
   projectId : "66c91d51-2dfa-42be-bd55-f92615146d7c" 
   requiredReviewerCount : 0 
   status : "TODO" 
   tags : ["c50329f8-47ab-4c53-8bc9-087bf912f17b"] 
   title : "담당자 테스트" 
   urgent : false
   ```
    <img width="420" height="216" alt="image" src="https://github.com/user-attachments/assets/ebff8808-0699-4882-a6a6-175836b22879" />

<br/>

- 버그를 수정하면서 발견한 **문제점**입니다.
    - 정적인 데이터와 동적인 UI의 불일치가 있었습니다. 프로젝트 페이지와 나의 할 일 페이지의 가장 큰 차이는 `projectId를 언제 알 수 있느냐`였습니다.
        > **[프로젝트 페이지]** 
        > 진입할 때 이미 projectId를 알고 있습니다. 훅이 실행되자마자 해당 프로젝트의 멤버 목록을 성공적으로 가져오고, 제출 시에도 그 목록에서 담당자를 찾아 ID를 매핑할 수 있었습니다.

        > **[나의 할 일 페이지]**
        > 처음에는 projectId가 비어 있거나 기본값입니다. 사용자가 모달을 연 뒤에야 프로젝트를 선택합니다. 하지만 기존 코드는 훅이 처음 호출될 때 전달받은 initialProjectId만 바라보고 멤버를 조회하고 있었습니다.

        -> 결과적으로 사용자가 프로젝트를 'A'로 선택하고 담당자를 골랐다 하더라도, 훅 내부의 projectMembers는 여전히 초기값(빈 배열)인 상태이고, 그렇게 되면 handleConfirm 실행 시, 빈 배열에서 담당자 이름을 찾으려니 결과가 항상 []가 되어 서버로 전송되게 되니, 담당자가 빈 배열로 전송되어 담당자가 설정되지 않는 것으로 보였던 것입니다.

<br/>

- 이러한 문제점에 대한 **해결방안**은 아래와 같습니다.
    > `form.watch`를 사용하여 폼의 상태 변화를 감지하여 쿼리를 실시간으로 동기화하도록 수정했습니다.

    - `form.watch('projectId')`를 사용하여 사용자가 UI에서 프로젝트를 바꿀 때마다 그 값을 즉각적으로 알아내도록 했습니다. 이 값을 `useProjectMembersQuery의 인자`로 전달함으로써, 프로젝트가 선택되는 순간 해당 프로젝트의 멤버 목록을 `refetch` 하게 됩니다.
    - 이렇게 수정하게 되면 `projectMembers`는 사용자가 선택한 프로젝트의 최신 멤버 리스트를 담고 있습니다. 그렇기에 handleConfirm이 실행될 때 이 업데이트된 리스트를 참조하게 되고, 이에 더하여 담당자 이름을 가지고 올바른 id를 찾아낼 수 있게 되었습니다.
   - 추가적으로, 할 일 생성에서는 담당자 수에 따라 `필요 리뷰어 수`가 달라지는 검증 로직이 있었습니다. 이 부분에 있어서도 useMemo와 useEffect를 활용해 멤버 목록이 바뀔 때마다 zodResolver를 갱신해 주어, 바뀐 프로젝트 환경에서도 실시간으로 에러를 잡아낼 수 있도록 보완했습니다.

<br/>

### ❗ 참고 사항

- 없음

<br/>

### #️⃣ 연관 이슈

- Close #348 
