### PR TITLE
✨ (#320) 사이드바 반응형 도입

### DIFF
--- a/src/app/layout/AppLayout.tsx
+++ b/src/app/layout/AppLayout.tsx
@@ -1,15 +1,25 @@
 import { SidebarProvider } from '@/shared/components/shadcn/sidebar';
 import AppSidebar from '@/widgets/AppSidebar';
 import { Outlet } from 'react-router-dom';
+import { useRef } from 'react';
+import FloatingSidebarTrigger from '@/features/sidebar/components/FloatingSidebarTrigger';
 
 const AppLayout = () => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
   return (
     <SidebarProvider defaultOpen={false}>
-      <div className="flex w-screen h-screen">
+      <div
+        ref={containerRef}
+        className="flex w-screen h-screen relative overflow-hidden touch-none"
+      >
         <AppSidebar />
+
         <main className="flex-1 flex flex-col min-w-0">
           <Outlet />
         </main>
+
+        <FloatingSidebarTrigger containerRef={containerRef} />
       </div>
     </SidebarProvider>
   );

--- a/src/features/sidebar/components/FloatingSidebarTrigger.tsx
+++ b/src/features/sidebar/components/FloatingSidebarTrigger.tsx
@@ -1,0 +1,56 @@
+import { SidebarTrigger } from '@/shared/components/shadcn/sidebar';
+import { motion } from 'framer-motion';
+import { useState } from 'react';
+
+interface FloatingSidebarTriggerProps {
+  containerRef: React.RefObject<HTMLDivElement | null>;
+}
+
+const FloatingSidebarTrigger = ({ containerRef }: FloatingSidebarTriggerProps) => {
+  const [isDragging, setIsDragging] = useState(false);
+  const [pressStart, setPressStart] = useState(0);
+
+  const handlePointerDown = () => {
+    setPressStart(Date.now());
+    setIsDragging(false);
+  };
+
+  const handlePointerUp = (e: React.PointerEvent) => {
+    const pressDuration = Date.now() - pressStart;
+
+    if (pressDuration < 250 && !isDragging) {
+      e.stopPropagation();
+
+      const triggerButton = e.currentTarget.querySelector('button');
+      triggerButton?.click();
+    }
+  };
+
+  return (
+    <motion.div
+      drag
+      dragMomentum={false}
+      dragElastic={0.2}
+      dragConstraints={containerRef}
+      onDragStart={() => setIsDragging(true)}
+      onDragEnd={() => setIsDragging(false)}
+      onPointerDown={handlePointerDown}
+      onPointerUp={handlePointerUp}
+      className="
+        fixed bottom-5 right-5 z-50 
+        md:hidden 
+        backdrop-blur-md 
+        shadow-md
+        rounded-full p-1
+        cursor-grab active:cursor-grabbing
+        bg-white/70
+      "
+    >
+      <div className="pointer-events-none">
+        <SidebarTrigger className="rounded-full p-5" />
+      </div>
+    </motion.div>
+  );
+};
+
+export default FloatingSidebarTrigger;

--- a/src/shared/components/shadcn/sidebar.tsx
+++ b/src/shared/components/shadcn/sidebar.tsx
@@ -10,6 +10,13 @@ import { cn } from '@/shared/lib/utils';
 import { Button } from '@/shared/components/shadcn/button';
 import { Input } from '@/shared/components/shadcn/input';
 import { Separator } from '@/shared/components/shadcn/separator';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/shared/components/shadcn/sheet';
 import { Skeleton } from '@/shared/components/shadcn/skeleton';
 import {
   Tooltip,
@@ -21,6 +28,7 @@ import {
 const SIDEBAR_COOKIE_NAME = 'sidebar_state';
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 const SIDEBAR_WIDTH = '15rem';
+const SIDEBAR_WIDTH_MOBILE = '4.688rem';
 const SIDEBAR_WIDTH_ICON = '4.688rem'; // 75px
 const SIDEBAR_KEYBOARD_SHORTCUT = 'b';
 
@@ -143,7 +151,7 @@ function SidebarProvider({
 function Sidebar({
   side = 'left',
   variant = 'sidebar',
-  collapsible = 'none',
+  collapsible = 'offcanvas',
   className,
   children,
   ...props
@@ -152,7 +160,7 @@ function Sidebar({
   variant?: 'sidebar' | 'floating' | 'inset';
   collapsible?: 'offcanvas' | 'icon' | 'none';
 }) {
-  const { state } = useSidebar();
+  const { isMobile, state, openMobile, setOpenMobile } = useSidebar();
 
   if (collapsible === 'none') {
     return (
@@ -166,6 +174,31 @@ function Sidebar({
       >
         {children}
       </div>
+    );
+  }
+
+  if (isMobile) {
+    return (
+      <Sheet open={openMobile} onOpenChange={setOpenMobile} {...props}>
+        <SheetContent
+          data-sidebar="sidebar"
+          data-slot="sidebar"
+          data-mobile="true"
+          className="bg-sidebar text-sidebar-foreground border-none rounded-r-md w-(--sidebar-width) p-0 [&>button]:hidden"
+          style={
+            {
+              '--sidebar-width': SIDEBAR_WIDTH_MOBILE,
+            } as React.CSSProperties
+          }
+          side={side}
+        >
+          <SheetHeader className="sr-only">
+            <SheetTitle>Sidebar</SheetTitle>
+            <SheetDescription>Displays the mobile sidebar.</SheetDescription>
+          </SheetHeader>
+          <div className="flex h-full w-full flex-col">{children}</div>
+        </SheetContent>
+      </Sheet>
     );
   }
 
@@ -224,7 +257,7 @@ function SidebarTrigger({ className, onClick, ...props }: React.ComponentProps<t
     <Button
       data-sidebar="trigger"
       data-slot="sidebar-trigger"
-      variant="ghost"
+      variant="defaultBoost"
       size="icon"
       className={cn('size-7', className)}
       onClick={(event) => {


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약

- 모바일에서도 사이드바를 사용할 수 있도록 반응형 도입했습니다.


<br/>

### ✨ 작업 내용

- 이전까지는 모바일 환경에서 사이드바가 아예 사라져서 사이드바를 사용할 수 없었습니다.
- 사이드바를 열 수 있는 버튼(trigger)을 구현하고 화면의 적절한 위치에 배치 후 사용할 수 있도록 했습니다.

<br/>

#### [구현 의도]
- 초기에는 플로팅 버튼을 만들어 한 위치에 배치하려고 했습니다. 
- 오른쪽 하단에 두었더니 칸반보드 일부를 가리게 되어 불편함이 있었습니다.
- 플로팅 버튼 없이 사이드바를 띄워두자니 모바일 환경 특성상 화면이 좁아 추후 다른 페이지 구현 시 사용할 수 있는 면적이 너무 좁을 것 같았습니다.
- 그래서 플로팅 버튼을 기본적으로 오른쪽 하단에 두되, `원하는 위치로 이동시킬 수 있는 플로팅 버튼을 구현하자!` 라는 생각을 하게 되어 구현해보았습니다.

<br/>

#### [구현 내용]
- 기존에 삭제하셨던 shadcn 사이드바 컴포넌트 내의 모바일 관련 코드를 복구해주었습니다.
- 모바일 전용으로 사용할 `드래그 가능한 Floating Sidebar Trigger`을 구현했습니다.
- 짧게 탭 -> 사이드바 열림
- 길게 누르거나 이동 시 -> 버튼 이동

![녹음 2026-01-17 232048](https://github.com/user-attachments/assets/a7c20ae4-1745-4830-b55c-26f01db04c0c)

<br/>

- 드래그 영역을 화면 컨테이너로 제한하기 위해 containerRef를 props로 전달했습니다.
- `dragConstraints={containerRef}`를 통해 버튼이 화면 밖으로 벗어나지 않도록 제한했습니다.
- 드래그와 탭 구분 로직이 필요하여 `isDragging`와 `pressStart`를 상태로 관리했습니다.
- `pressStart`는 pointer down 시점의 timestamp 저장하며, `isDragging`은 실제 drag가 시작되었는지 여부를 나타냅니다.

<br/>

- 중요한 로직은 아래와 같습니다.
    ```ts
    // pointerDown
    const handlePointerDown = () => {
    setPressStart(Date.now());
    setIsDragging(false);
  };
    ```
    > 여기서 사용자의 입력을 우선 `클릭 가능 상태`로 시작하며, 이후 드래그가 발생하면 isDragging이 true로 변경됩니다.
    
    <br/>

    ```ts
    // pointerUp
    const pressDuration = Date.now() - pressStart;

    if (pressDuration < 250 && !isDragging) {
      e.stopPropagation();
      const triggerButton = e.currentTarget.querySelector('button');
      triggerButton?.click();
    }
    ```
    > 만약 250ms 이내거나 드래그가 아니라면 탭으로 판단하며, 드래그 중이었거나 오래 눌렀을 경우 클릭 처리하지 않도록 했습니다. 또한 stopPropagation()으로 이벤트 전파를 차단했습니다. stopProppagation()을 쓰지 않으면 다른 클릭 로직과 겹쳐져 의도치 않은 클릭 문제가 생길 수 있어 써주었습니다!!


<br/>
<br/>

### ❗ 참고 사항

- 사이드바 내 항목(프로젝트 목록, 알림 목록)은 구현되지 않은 상태입니다. 
- 해당 사이드바 반응형 PR 머지 후 이어서 작업해주시면 될 것 같습니다.
- 확인해보니 프로젝트 목록은 sidebar 폴더 내에, 알림 목록은 notification 폴더 내에 있더라구요! 폴더 구조 부분도 확인 필요할 듯 합니다!

<br/>

### #️⃣ 연관 이슈

- Close #320 
