### PR TITLE
✨ (#359) 프로젝트 참여/생성 모달 반응형 도입

### DIFF
--- a/src/features/project/components/ProjectCreateModal/ProjectCreateModalContent.tsx
+++ b/src/features/project/components/ProjectCreateModal/ProjectCreateModalContent.tsx
@@ -38,7 +38,7 @@ const ProjectCreateModalContent = ({ onConfirm, onJoinClick }: ProjectCreateModa
           className="border-gray-400 h-10 focus:ring-transparent focus:border-gray-600"
         />
       </div>
-      <DialogFooter className="!mt-0 pt-4 border-t border-gray-300 flex !justify-between items-center">
+      <DialogFooter className="!mt-0 pt-4 border-t border-gray-300 flex flex-col-reverse sm:flex-row sm:justify-between items-stretch sm:items-center gap-4">
         <Button
           onClick={() => {
             resetModal();
@@ -50,19 +50,21 @@ const ProjectCreateModalContent = ({ onConfirm, onJoinClick }: ProjectCreateModa
         >
           참여할래요
         </Button>
-        <div className="flex gap-2">
+
+        <div className="flex flex-col-reverse sm:flex-row gap-2 w-full sm:w-auto">
           <Button
             onClick={backModal}
             variant="outline"
             disabled={isLoading}
-            className="border-gray-400 sm:w-20 hover:bg-gray-200"
+            className="border-gray-400 sm:w-20 w-full hover:bg-gray-200"
           >
             취소
           </Button>
+
           <Button
             onClick={handleConfirm}
             disabled={!projectName.trim() || isLoading}
-            className="bg-boost-blue sm:w-20 hover:bg-boost-blue-pressed cursor-pointer"
+            className="bg-boost-blue sm:w-20 w-full hover:bg-boost-blue-pressed cursor-pointer"
           >
             생성
           </Button>

--- a/src/features/project/components/ProjectCreateModal/ProjectCreateModalContent.tsx
+++ b/src/features/project/components/ProjectCreateModal/ProjectCreateModalContent.tsx
@@ -46,7 +46,7 @@ const ProjectCreateModalContent = ({ onConfirm, onJoinClick }: ProjectCreateModa
           }}
           variant="outline"
           disabled={isLoading}
-          className="border-none text-gray-500 p-1 hover:text-gray-600 underline cursor-pointer hover:bg-gray-100"
+          className="border-none text-gray-500 p-1 underline hover:text-gray-600 hover:bg-gray-100"
         >
           참여할래요
         </Button>
@@ -56,7 +56,7 @@ const ProjectCreateModalContent = ({ onConfirm, onJoinClick }: ProjectCreateModa
             onClick={backModal}
             variant="outline"
             disabled={isLoading}
-            className="border-gray-400 sm:w-20 w-full hover:bg-gray-200"
+            className="border-gray-400 w-full sm:w-20 hover:bg-gray-200"
           >
             취소
           </Button>
@@ -64,7 +64,7 @@ const ProjectCreateModalContent = ({ onConfirm, onJoinClick }: ProjectCreateModa
           <Button
             onClick={handleConfirm}
             disabled={!projectName.trim() || isLoading}
-            className="bg-boost-blue sm:w-20 w-full hover:bg-boost-blue-pressed cursor-pointer"
+            className="bg-boost-blue w-full sm:w-20 hover:bg-boost-blue-pressed"
           >
             생성
           </Button>

--- a/src/features/project/components/ProjectJoinModal/ProjectJoinCodeInputModalContent.tsx
+++ b/src/features/project/components/ProjectJoinModal/ProjectJoinCodeInputModalContent.tsx
@@ -63,7 +63,7 @@ const ProjectJoinCodeInputModalContent = ({
           className="border-gray-400 h-10 focus:ring-transparent focus:border-gray-600"
         />
       </div>
-      <DialogFooter className="!mt-0 pt-4 border-t border-gray-300 flex !justify-between items-center">
+      <DialogFooter className="!mt-0 pt-4 border-t border-gray-300 flex flex-col-reverse sm:flex-row sm:justify-between gap-4">
         <Button
           onClick={() => {
             resetModal();
@@ -75,21 +75,21 @@ const ProjectJoinCodeInputModalContent = ({
         >
           생성할래요
         </Button>
-        <div className="flex gap-2">
+        <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
           <Button
             onClick={backModal}
             variant="outline"
             disabled={isLoading}
-            className="border-gray-400 sm:w-20 hover:bg-gray-200 cursor-pointer"
+            className="border-gray-400 w-full sm:w-20 hover:bg-gray-200 cursor-pointer order-2 sm:order-1"
           >
             취소
           </Button>
           <Button
             onClick={handleConfirm}
             disabled={!joinCode || isLoading}
-            className="bg-boost-blue sm:w-20 hover:bg-boost-blue-pressed cursor-pointer"
+            className="bg-boost-blue w-full sm:w-20 hover:bg-boost-blue-pressed cursor-pointer order-1 sm:order-2"
           >
-            입력
+            참여
           </Button>
         </div>
       </DialogFooter>

--- a/src/features/project/components/ProjectJoinModal/ProjectJoinCodeInputModalContent.tsx
+++ b/src/features/project/components/ProjectJoinModal/ProjectJoinCodeInputModalContent.tsx
@@ -63,7 +63,7 @@ const ProjectJoinCodeInputModalContent = ({
           className="border-gray-400 h-10 focus:ring-transparent focus:border-gray-600"
         />
       </div>
-      <DialogFooter className="!mt-0 pt-4 border-t border-gray-300 flex flex-col-reverse sm:flex-row sm:justify-between gap-4">
+      <DialogFooter className="!mt-0 pt-4 border-t border-gray-300 flex flex-col-reverse sm:flex-row sm:justify-between items-stretch sm:items-center gap-4">
         <Button
           onClick={() => {
             resetModal();
@@ -71,23 +71,25 @@ const ProjectJoinCodeInputModalContent = ({
           }}
           variant="outline"
           disabled={isLoading}
-          className="border-none text-gray-500 p-1 hover:text-gray-600 underline cursor-pointer hover:bg-gray-100"
+          className="border-none text-gray-500 p-1 underline hover:text-gray-600 hover:bg-gray-100"
         >
           생성할래요
         </Button>
-        <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
+
+        <div className="flex flex-col-reverse sm:flex-row gap-2 w-full sm:w-auto">
           <Button
             onClick={backModal}
             variant="outline"
             disabled={isLoading}
-            className="border-gray-400 w-full sm:w-20 hover:bg-gray-200 cursor-pointer order-2 sm:order-1"
+            className="border-gray-400 w-full sm:w-20 hover:bg-gray-200"
           >
             취소
           </Button>
+
           <Button
             onClick={handleConfirm}
             disabled={!joinCode || isLoading}
-            className="bg-boost-blue w-full sm:w-20 hover:bg-boost-blue-pressed cursor-pointer order-1 sm:order-2"
+            className="bg-boost-blue w-full sm:w-20 hover:bg-boost-blue-pressed"
           >
             참여
           </Button>

--- a/src/features/project/hooks/useProjectModals.tsx
+++ b/src/features/project/hooks/useProjectModals.tsx
@@ -13,7 +13,7 @@ export const useProjectModals = () => {
   const showCreateProjectModal = () => {
     showCustom({
       title: '프로젝트 생성하기',
-      description: '프로젝트 이름을 입력하면, 새로운 프로젝트를 생성할 수 있어요.',
+      description: '프로젝트 이름을 입력하면, 새 프로젝트를 생성할 수 있어요.',
       content: (
         <ProjectCreateModalContent
           onConfirm={async (projectName) => {


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약

- 프로젝트 참여/생성 모달에 반응형을 도입했습니다.

<br/>

### ✨ 작업 내용
- 기본 클래스는 `모바일`, `sm:`을 통해 `데스크탑` 오버라이드 방식을 사용했습니다.
- 모바일에서는 `items-stretch`를 통한 버튼 세로 스택, 데스크탑에서는 `items-center`를 통한 버튼 가로 스택을 적용했습니다.
- 모바일에서는 생성(참여) 버튼이 위로, 데스크탑에서는 생성(참여) 버튼이 오른쪽에 있어야하므로, 버튼을 그룹 단위로 관리했습니다. → `flex-col-reverse sm:flex-row` 사용하여 구현
- 버튼 크기는 모바일 환경에서 `w-full`을 이용해 모달에 꽉 차게 함으로써 터치 영역을 넓게 확보했습니다. 데스크탑 환경은 동일하게 `w-20` 크기를 유지했습니다.
- 같은 UI지만 각자 다른 스타일 클래스로 작성되어있던 내용을 통일했습니다.

<br/>

#### 1. 프로젝트 참여 모달 - 데스크탑 
<img width="696" height="360" alt="image" src="https://github.com/user-attachments/assets/445596f3-7197-4c05-ba43-bab9372ca843" />

<br/>
<br/>

#### 2. 프로젝트 참여 모달 - 모바일
<img width="506" height="877" alt="image" src="https://github.com/user-attachments/assets/a434a456-7265-4e06-9cfd-699955efae7d" />

<br/>
<br/>

#### 3. 프로젝트 생성 모달 - 데스크탑
<img width="672" height="330" alt="image" src="https://github.com/user-attachments/assets/9453cbc8-22fa-4b87-b826-583bcc86bad3" />

<br/>
<br/>

#### 4. 프로젝트 생성 모달 - 모바일
<img width="506" height="876" alt="image" src="https://github.com/user-attachments/assets/e920d65c-6c74-44f4-9317-81bbb1d4426b" />

<br/>
<br/>

### ❗ 참고 사항

- 테블릿 기준은 아래처럼 데스크탑과 동일한 사이즈 모달이 제공됩니다!
<img width="591" height="835" alt="image" src="https://github.com/user-attachments/assets/a0398ee9-6da2-4540-aec9-656afb07f1d4" />

<br/>

### #️⃣ 연관 이슈

- Close #359 
