### PR TITLE
♻️ (#362, #371) 랜딩페이지 반응형 개선 + 코드 리팩터링

### DIFF
--- a/src/features/landing/components/FeatureSection.tsx
+++ b/src/features/landing/components/FeatureSection.tsx
@@ -1,28 +1,20 @@
 import { motion } from 'framer-motion';
-import {
-  fadeInDown,
-  fadeInLeft,
-  fadeInRight,
-  fadeInUp,
-  scaleUp,
-} from '@/shared/utils/animations/motionVariants';
 import { cn } from '@/shared/lib/utils';
+import { animationVariants, type AnimationType } from '@/shared/utils/animations/animationVariants';
 
 interface FeatureSectionProps {
   title: string;
   subtitle: string;
   description: string;
   image?: string;
-  animationType?: 'left' | 'right' | 'up' | 'down' | 'scale';
+  animationType?: AnimationType;
 }
 
-const animationVariants = {
-  left: fadeInLeft,
-  right: fadeInRight,
-  up: fadeInUp,
-  down: fadeInDown,
-  scale: scaleUp,
-};
+const motionBaseProps = {
+  initial: 'hidden',
+  whileInView: 'visible',
+  viewport: { once: true, amount: 0.3 },
+} as const;
 
 const FeaturesSection = ({
   title,
@@ -31,23 +23,28 @@ const FeaturesSection = ({
   image,
   animationType = 'left',
 }: FeatureSectionProps) => {
+  const isLeft = animationType === 'left';
+  const isRight = animationType === 'right';
+
   return (
     <div
       className={cn('flex flex-col w-fit items-center max-w-6xl mx-auto py-20 px-6 gap-12', {
-        'ml-30': animationType === 'left',
-        'mr-30': animationType === 'right',
+        'ml-30 ': isLeft,
+        'mr-30': isRight,
       })}
     >
       <motion.div
-        className={'flex-1'}
-        initial="hidden"
-        whileInView="visible"
-        viewport={{ once: true, amount: 0.3 }}
+        className={cn(
+          'flex flex-col flex-1',
+          isLeft && 'items-end text-right sm:items-start sm:text-left',
+          isRight && 'items-start text-left sm:items-end sm:text-right',
+        )}
+        {...motionBaseProps}
         variants={animationVariants[animationType]}
       >
-        <h2 className="text-4xl font-bold mb-4 items-center">{title}</h2>
-        <p className="title1-regular text-gray-600 mb-4">{subtitle}</p>
-        <p className="subtitle1-regular text-gray-500">{description}</p>
+        <h2 className="text-xl sm:text-4xl font-bold mb-4 items-center">{title}</h2>
+        <p className="title2-regular sm:title1-regular text-gray-600 mb-2 sm:mb-4">{subtitle}</p>
+        <p className="body2-regular sm:subtitle1-regular text-gray-500">{description}</p>
       </motion.div>
 
       {image && (
@@ -55,9 +52,7 @@ const FeaturesSection = ({
           src={image}
           alt={title}
           className="flex-1 max-w-5xl"
-          initial="hidden"
-          whileInView="visible"
-          viewport={{ once: true, amount: 0.3 }}
+          {...motionBaseProps}
           variants={animationVariants[animationType]}
         />
       )}

--- a/src/features/landing/components/HeroSection.tsx
+++ b/src/features/landing/components/HeroSection.tsx
@@ -1,32 +1,35 @@
-import { Button } from '@/shared/components/shadcn/button';
 import { useNavigate } from 'react-router-dom';
-import { ROUTE_PATH } from '@/app/routes/Router';
 import { motion } from 'framer-motion';
+import { ROUTE_PATH } from '@/app/routes/Router';
+import { Button } from '@/shared/components/shadcn/button';
 import Boost_3D from '@/shared/assets/images/boost/boost-logo-3d.png';
+import { floatVariant } from '@/shared/utils/animations/motionVariants';
 
 const HeroSection = () => {
   const navigate = useNavigate();
 
   return (
-    <div className="relative z-10 max-w-8xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-      <div className="grid grid-cols-1 lg:grid-cols-2 items-center min-h-[80vh] gap-6 sm:gap-10">
-        <div className="space-y-6 sm:space-y-8 text-center lg:text-left">
+    <div className="relative z-10 max-w-8xl mx-auto px-4 sm:px-6 lg:px-8 py-16 md:py-20 lg:py-16">
+      <div className="grid grid-cols-1 lg:grid-cols-2 items-center lg:min-h-[80vh] gap-0 sm:gap-10">
+        <div className="space-y-6 sm:space-y-8 text-center lg:text-left order-2 lg:order-1">
           <h1 className="text-3xl sm:text-4xl lg:text-6xl font-bold text-gray-900 leading-tight">
             팀 프로젝트를
             <br />
             <span className="text-boost-blue">쉽게 관리</span>하세요
           </h1>
 
-          <p className="text-lg sm:text-xl text-gray-600 leading-relaxed">
-            칸반보드로 진행 현황을 확인하고, 서로에게 피드백을 남겨보세요.
-            <br />
-            대학생 팀프로젝트에 필요한 기능들을 제공합니다!
+          <p className="text-sm sm:text-xl text-gray-600 leading-relaxed">
+            <span className="block sm:inline">칸반보드로 진행 현황을 확인하고,</span>
+            <span className="block sm:inline">서로에게 피드백을 남겨보세요.</span>
+            <br className="hidden sm:block" />
+            <span className="block sm:inline">대학생 팀프로젝트에 필요한 기능들을 제공합니다!</span>
           </p>
 
-          <div className="flex flex-col sm:flex-row gap-4 sm:justify-start">
+          <div className="flex flex-col lg:flex-row gap-4 lg:justify-start">
             <Button
               onClick={() => navigate(ROUTE_PATH.LOGIN)}
-              className="bg-boost-blue shadow-sm h-10 w-full sm:w-auto hover:bg-boost-blue-hover"
+              variant="defaultBoost"
+              className="lg:w-auto"
               size="lg"
             >
               서비스 경험하기
@@ -34,17 +37,12 @@ const HeroSection = () => {
           </div>
         </div>
 
-        {/* 이미지 영역 */}
         <motion.img
           src={Boost_3D}
           alt="Boost 3D"
-          className="w-[400px] justify-self-center mt-6 lg:mt-0"
-          animate={{ y: [0, -15, 0] }}
-          transition={{
-            duration: 3,
-            repeat: Infinity,
-            ease: 'easeInOut',
-          }}
+          className="order-1 lg:order-2 w-[250px] xl:w-[400px] justify-self-center"
+          variants={floatVariant}
+          animate="animate"
         />
       </div>
     </div>

--- a/src/features/landing/components/LandingFooter.tsx
+++ b/src/features/landing/components/LandingFooter.tsx
@@ -9,7 +9,7 @@ const LandingFooter = () => {
         <div className="flex flex-col items-center text-center">
           <h2 className="text-3xl font-bold mb-6">궁금한 점이 있으신가요?</h2>
 
-          <p className="text-gray-300 mb-12 text-lg leading-relaxed">
+          <p className="text-gray-300 mb-12 text-sm sm:text-lg leading-relaxed">
             BOOST에 대해 더 자세히 알고 싶거나 도움이 필요하시다면 <br />
             아래 버튼을 눌러 네이버폼으로 이동해주세요.
           </p>
@@ -35,7 +35,7 @@ const LandingFooter = () => {
           <Separator className="mt-16 bg-gray-900/70" />
 
           <p className="mt-6 text-xs text-gray-500 hover:text-gray-400 transition-colors">
-            © 2025 BOOST. All rights reserved.
+            © {new Date().getFullYear()} BOOST. All rights reserved.
           </p>
         </div>
       </div>

--- a/src/features/landing/components/LandingNavigation.tsx
+++ b/src/features/landing/components/LandingNavigation.tsx
@@ -23,60 +23,73 @@ const LandingNavigation = () => {
     setIsOpen(false);
   };
 
+  const MobileMenu = (
+    <div className="md:hidden absolute top-full left-0 w-full bg-gray-100 shadow-md flex flex-col items-center py-4 space-y-4 px-6">
+      {navItems.map((item) => (
+        <button
+          key={item.href}
+          onClick={() => handleNavClick(item.href)}
+          className="text-gray-700 hover:text-boost-blue text-lg transition w-full"
+        >
+          {item.label}
+        </button>
+      ))}
+
+      <Button
+        onClick={() => {
+          navigate(ROUTE_PATH.LOGIN);
+          setIsOpen(false);
+        }}
+        variant="defaultBoost"
+        className="w-full"
+      >
+        Sign In
+      </Button>
+    </div>
+  );
+
   return (
     <nav className="fixed top-0 left-0 w-screen bg-gray-100 shadow-sm z-50">
-      <div className="px-6 md:px-0 max-w-7xl mx-auto flex items-center justify-between py-3">
-        <div className="text-xl font-bold text-boost-blue">BOOST</div>
+      <div className="px-4 sm:px-6 xl:px-0 max-w-7xl mx-auto flex items-center justify-between py-3">
+        <button
+          className="text-xl font-bold text-boost-blue cursor-pointer"
+          onClick={() => handleNavClick('#home')}
+        >
+          BOOST
+        </button>
 
         <div className="hidden md:flex space-x-12">
           {navItems.map((item) => (
-            <a
+            <button
               key={item.href}
-              href={item.href}
-              className="text-gray-700 hover:text-boost-blue transition"
+              onClick={() => handleNavClick(item.href)}
+              className="text-gray-700 hover:text-boost-blue transition cursor-pointer"
             >
               {item.label}
-            </a>
+            </button>
           ))}
         </div>
 
         <div className="hidden md:block">
           <Button
             onClick={() => navigate(ROUTE_PATH.LOGIN)}
-            className="rounded-full bg-boost-blue text-gray-100 hover:bg-boost-blue-hover"
+            variant="defaultBoost"
+            className="rounded-full"
           >
             Sign In
           </Button>
         </div>
 
-        <button className="md:hidden text-gray-700" onClick={() => setIsOpen(!isOpen)}>
+        <button
+          className="md:hidden text-gray-700"
+          onClick={() => setIsOpen((prev) => !prev)}
+          aria-label="Toggle menu"
+        >
           {isOpen ? <X size={24} /> : <Menu size={24} />}
         </button>
       </div>
 
-      {isOpen && (
-        <div className="md:hidden absolute top-full left-0 w-full bg-gray-100 shadow-md flex flex-col items-center py-4 space-y-4 px-6">
-          {navItems.map((item) => (
-            <button
-              key={item.href}
-              onClick={() => handleNavClick(item.href)}
-              className="text-gray-700 hover:text-boost-blue text-lg transition w-full"
-            >
-              {item.label}
-            </button>
-          ))}
-
-          <Button
-            onClick={() => {
-              navigate(ROUTE_PATH.LOGIN);
-              setIsOpen(false);
-            }}
-            className="bg-boost-blue text-gray-100 hover:bg-boost-blue-hover w-full"
-          >
-            Sign In
-          </Button>
-        </div>
-      )}
+      {isOpen && MobileMenu}
     </nav>
   );
 };

--- a/src/features/landing/components/TeamSection.tsx
+++ b/src/features/landing/components/TeamSection.tsx
@@ -18,21 +18,21 @@ const TeamSection = () => {
   return (
     <div className="py-35 bg-white">
       <div className="text-center mb-18">
-        <h2 className="text-4xl font-bold text-gray-800">Boost Team</h2>
-        <p className="mt-4 text-lg text-gray-500">
+        <h2 className="text-2xl sm:text-4xl font-bold text-gray-800">Boost Team</h2>
+        <p className="mt-4 subtitle2-regular sm:text-lg text-gray-500">
           프로젝트를 열심히 이끌어주고 있는 Boost 팀원들입니다!
         </p>
       </div>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-6 px-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-7 sm:gap-6 px-4">
         {teamMembers.map((member, idx) => (
           <Card
             key={idx}
-            className="border-gray-300 shadow-md rounded-xl items-center p-6 w-full h-full min-w-[250px] min-h-[300px] flex flex-col justify-center transform transition hover:-translate-y-2 hover:shadow-xl"
+            className="border-gray-300 shadow-md rounded-xl flex flex-col items-center justify-center w-full h-full min-w-[180px] min-h-[220px] xl:min-w-[250px] xl:min-h-[300px] p-4 sm:p-6 transform transition hover:-translate-y-2 hover:shadow-xl"
           >
             <img
               src={member.img}
-              className={cn('w-30 rounded-full p-2.5', {
+              className={cn('w-24 xl:w-30 rounded-full p-2.5', {
                 'bg-boost-blue': member.role === 'Backend',
                 'bg-boost-orange': member.role === 'Frontend',
               })}
@@ -40,8 +40,12 @@ const TeamSection = () => {
             />
 
             <CardContent className="text-center space-y-3 mt-4 flex-1">
-              <CardTitle className="text-xl font-bold text-gray-800">{member.name}</CardTitle>
-              <CardDescription className="text-md text-gray-600">{member.role}</CardDescription>
+              <CardTitle className="text-md sm:text-xl font-bold text-gray-800">
+                {member.name}
+              </CardTitle>
+              <CardDescription className="text-sm sm:text-md text-gray-600">
+                {member.role}
+              </CardDescription>
             </CardContent>
           </Card>
         ))}

--- a/src/features/landing/constants/landingConstants.ts
+++ b/src/features/landing/constants/landingConstants.ts
@@ -1,0 +1,28 @@
+export const SECTION_INTERSECTION_THRESHOLD = 0.6;
+
+export const FEATURES = [
+  {
+    title: '팀 프로젝트 관리의 핵심, 칸반보드',
+    subtitle: '간편한 할 일 이동',
+    description: '프로젝트의 진행 상황을 파악해보세요',
+    animationType: 'left' as const,
+  },
+  {
+    title: '실시간 피드백',
+    subtitle: '팀원의 작업을 바로 확인',
+    description: '각자 맡은 작업에 피드백을 남기고, 빠르게 소통할 수 있어요.',
+    animationType: 'right' as const,
+  },
+  {
+    title: '승인 시스템',
+    subtitle: '팀원에게 작업 승인 요청',
+    description: '완료한 작업을 팀원에게 승인받아 작업 진행 상황을 명확하게 확인하세요.',
+    animationType: 'left' as const,
+  },
+  {
+    title: '익명 & AI 댓글',
+    subtitle: '감정 충돌 없는 소통',
+    description: '익명 댓글과 AI 기반 댓글 변환으로 팀원 간 소통을 부드럽게 만들어줍니다.',
+    animationType: 'right' as const,
+  },
+];

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,18 +1,33 @@
+import { useEffect } from 'react';
 import LandingNavigation from '@/features/landing/components/LandingNavigation';
 import HeroSection from '@/features/landing/components/HeroSection';
 import FeatureSection from '@/features/landing/components/FeatureSection';
 import LandingFooter from '@/features/landing/components/LandingFooter';
 import TeamSection from '@/features/landing/components/TeamSection';
-import { useEffect } from 'react';
+import {
+  FEATURES,
+  SECTION_INTERSECTION_THRESHOLD,
+} from '@/features/landing/constants/landingConstants';
 
 const LandingPage = () => {
   useEffect(() => {
-    if (window.location.hash) {
-      window.history.replaceState(null, '', window.location.pathname);
-      setTimeout(() => window.scrollTo({ top: 0, left: 0, behavior: 'auto' }), 0);
-    }
+    resetInitialHash();
+    const observer = observeSections();
+    return () => observer.disconnect();
+  }, []);
 
+  const resetInitialHash = () => {
+    if (!window.location.hash) return;
+
+    window.history.replaceState(null, '', window.location.pathname);
+    setTimeout(() => {
+      window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+    }, 0);
+  };
+
+  const observeSections = () => {
     const sections = document.querySelectorAll<HTMLElement>('section[id]');
+
     const observer = new IntersectionObserver(
       (entries) => {
         entries.forEach((entry) => {
@@ -21,15 +36,15 @@ const LandingPage = () => {
           }
         });
       },
-      { threshold: 0.6 },
+      { threshold: SECTION_INTERSECTION_THRESHOLD },
     );
-    sections.forEach((section) => observer.observe(section));
 
-    return () => observer.disconnect();
-  }, []);
+    sections.forEach((section) => observer.observe(section));
+    return observer;
+  };
 
   return (
-    <div className="flex flex-col gap-4 justify-center items-center ">
+    <div className="flex flex-col gap-4 justify-center items-center">
       <LandingNavigation />
 
       <section id="home" aria-label="home 섹션">
@@ -37,30 +52,15 @@ const LandingPage = () => {
       </section>
 
       <section id="about" aria-label="기능 소개 섹션" className="w-full py-20">
-        <FeatureSection
-          title="팀 프로젝트 관리의 핵심, 칸반보드 "
-          subtitle="간편한 할 일 이동"
-          description="프로젝트의 진행 상황을 파악해보세요"
-          animationType="left"
-        />
-        <FeatureSection
-          title="실시간 피드백"
-          subtitle="팀원의 작업을 바로 확인"
-          description="각자 맡은 작업에 피드백을 남기고, 빠르게 소통할 수 있어요."
-          animationType="right"
-        />
-        <FeatureSection
-          title="승인 시스템"
-          subtitle="팀원에게 작업 승인 요청"
-          description="완료한 작업을 팀원에게 승인받아 프로젝트 진행 상황을 명확하게 확인하세요."
-          animationType="left"
-        />
-        <FeatureSection
-          title="익명 & AI 댓글"
-          subtitle="감정 충돌 없는 소통"
-          description="익명 댓글과 AI 기반 댓글 변환으로 팀원 간 소통을 부드럽게 만들어줍니다."
-          animationType="right"
-        />
+        {FEATURES.map((feature) => (
+          <FeatureSection
+            key={feature.title}
+            title={feature.title}
+            subtitle={feature.subtitle}
+            description={feature.description}
+            animationType={feature.animationType}
+          />
+        ))}
       </section>
 
       <section id="team" aria-label="팀 소개 섹션">

--- a/src/shared/utils/animations/animationVariants.ts
+++ b/src/shared/utils/animations/animationVariants.ts
@@ -1,0 +1,17 @@
+import {
+  fadeInDown,
+  fadeInLeft,
+  fadeInRight,
+  fadeInUp,
+  scaleUp,
+} from '@/shared/utils/animations/motionVariants';
+
+export const animationVariants = {
+  left: fadeInLeft,
+  right: fadeInRight,
+  up: fadeInUp,
+  down: fadeInDown,
+  scale: scaleUp,
+};
+
+export type AnimationType = keyof typeof animationVariants;


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약

- 랜딩 페이지 반응형 개선했습니다.
- 랜딩 페이지 관련 코드 리팩터링 진행했습니다.

<br/>

### ✨ 작업 내용

#### 1. 랜딩 페이지 - 상단 Navigation 바 반응형 개선했습니다.
- 기존에 태블릿 사이즈에서 상단바 양쪽이 화면에 살짝 붙어 UI가 어긋나는 느낌이 있었습니다.
- 이를 태블릿에서 상단바 양 옆 padding이 적절하게 나타날 수 있도록 수정했습니다.
- 왼쪽이 이전, 오른쪽이 이후입니다.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/b3e999d3-36df-44e2-a3b3-8fc2791781f2" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/8771b256-46c1-4ffc-bd70-b3a8c62603d2" />

<br/>
<br/>

#### 2. 랜딩 페이지 - Hero 섹션 반응형 개선했습니다.
- 기존 모바일에서의 UI가 조금 어색한 감이 있어서 자연스럽게 수정했습니다.
- 태블릿 사이즈 반응형도 추가했습니다.
- 왼쪽이 이전, 오른쪽이 이후입니다.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/f31a3e64-b7d5-43ef-846e-3bfef4ae5c97" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/7e4b2741-dd66-47ce-a64c-7e4100a55b9c" />

<br/>
<br/>

#### 3. 랜딩 페이지 - Features 섹션 반응형 개선했습니다.
- 데스크탑, 태블릿: 오른쪽에서 나타나는 feature text는 오른쪽으로 정렬되도록, 왼쪽에서 나타나는 feature text는 왼쪽으로 정렬되도록 함
- 모바일: 오른쪽에서 나타나는 feature text는 왼쪽으로 정렬되도록, 왼쪽에서 나타나는 feature text는 오른쪽으로 정렬되도록 함
- 눈으로 봤을 때 자연스럽도록 하기 위해 채택한 부분입니다.
- 왼쪽이 이전, 오른쪽이 이후입니다.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/eb930a4b-f1b9-4ebd-b9a3-46b54c5815b3" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/a90d6da3-1b12-4109-840f-131ef6542d1d" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/0fd00ff0-a537-4623-bf37-e559c005ea8d" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/2bf72fe9-4213-420e-8842-84095aa84aef" />


<br/>
<br/>

#### 4. 랜딩 페이지 - Team 소개 섹션 반응형 개선했습니다.
- 데스크탑: 기존과 동일합니다.
- 태블릿: 기본적으로 카드 사이즈를 줄여 깨지지 않도록 했습니다. 태블릿 사이즈마다 팀원 카드 grid가 바뀌도록 했습니다.
- 모바일: 태블릿과 동일하게 모바일 화면에 맞게 grid가 조정됩니다. 아바타 사이즈와 텍스트 사이즈도 줄어들도록 했습니다.
- 왼쪽이 이전, 오른쪽이 이후입니다.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/bf343542-ae98-4cfd-998a-4ee858ce84c8" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/614eb61b-a738-4341-ad43-ab9f739817b5" />

<br/>
<br/>

#### 5. 랜딩 페이지 - Footer 반응형 개선했습니다.
- 모바일에서 text 사이즈를 조금 줄였습니다.
- 왼쪽이 이전, 오른쪽이 이후입니다.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/663e1f77-f4cd-4852-8d8b-667c8ee3a853" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/06054f15-3431-4253-a14b-c37ad84838f0" />

<br/>
<br/>

#### 6. 그 외 리팩터링 사항
- `LandingPage` 코드의 가독성을 높이기 위해서 `landingConstants` 파일을 생성해 상수와 데이터를 분리했습니다.
- `animationVariants` 파일을 생성해 FeatureSection에서 사용하는 variants와 type을 분리했습니다. -> 추후 다른 코드에서도 사용할 가능성이 있을 것 같아 분리했습니다.
- 상단 내비게이션바 코드 가독성 향상을 위해 모바일 JSX를 분리했습니다. 
- 상단 내비게이션바 왼쪽에 위치한 `BOOST`에 메인 화면으로 이동하는 기능을 추가했습니다.
- 중간 중간 Button에 `variant="defaultBoost"` 사용하도록 수정했습니다.

<br/>

### ❗ 참고 사항(선택)

- 랜딩 페이지는 기능적인 부분은 크게 없어서 코드 가독성 개선 리팩터링 위주로 진행했습니다.
- 랜딩 페이지는 미리보기 배포에서 확인이 가능하니, 반응형 test 부탁드립니다! (기존 -> QA에서 확인, 적용된거 -> 미리보기 배포에서 확인)

<br/>

### #️⃣ 연관 이슈

- Close #362, #371 
