### PR TITLE
💄 (#420) Typography Token 확장 (display, caption 추가)

### DIFF
--- a/src/shared/design-tokens/typography.css
+++ b/src/shared/design-tokens/typography.css
@@ -1,4 +1,21 @@
 @theme {
+  /* 디스플레이 (Display) */
+  --display1-bold-font-size: 1.75rem;
+  --display1-bold-line-height: 36px;
+  --display1-bold-font-weight: 700;
+
+  --display1-regular-font-size: 1.75rem;
+  --display1-regular-line-height: 36px;
+  --display1-regular-font-weight: 400;
+
+  --display2-bold-font-size: 1.5rem;
+  --display2-bold-line-height: 32px;
+  --display2-bold-font-weight: 700;
+
+  --display2-regular-font-size: 1.5rem;
+  --display2-regular-line-height: 32px;
+  --display2-regular-font-weight: 400;
+
   /* 제목 (Title) */
   --title1-bold-font-size: 1.25rem;
   --title1-bold-line-height: 27px;
@@ -66,6 +83,37 @@
   --label2-regular-font-size: 0.75rem;
   --label2-regular-line-height: 16px;
   --label2-regular-font-weight: 400;
+
+  /* 보조 텍스트 (Caption) */
+  --caption1-bold-font-size: 0.6875rem;
+  --caption1-bold-line-height: 16px;
+  --caption1-bold-font-weight: 700;
+
+  --caption1-regular-font-size: 0.6875rem;
+  --caption1-regular-line-height: 16px;
+  --caption1-regular-font-weight: 400;
+}
+
+/* 디스플레이 (Display) */
+@utility display1-bold {
+  font-size: var(--display1-bold-font-size);
+  line-height: var(--display1-bold-line-height);
+  font-weight: var(--display1-bold-font-weight);
+}
+@utility display1-regular {
+  font-size: var(--display1-regular-font-size);
+  line-height: var(--display1-regular-line-height);
+  font-weight: var(--display1-regular-font-weight);
+}
+@utility display2-bold {
+  font-size: var(--display2-bold-font-size);
+  line-height: var(--display2-bold-line-height);
+  font-weight: var(--display2-bold-font-weight);
+}
+@utility display2-regular {
+  font-size: var(--display2-regular-font-size);
+  line-height: var(--display2-regular-line-height);
+  font-weight: var(--display2-regular-font-weight);
 }
 
 /* 제목 (Title) */
@@ -154,4 +202,16 @@
   font-size: var(--label2-regular-font-size);
   line-height: var(--label2-regular-line-height);
   font-weight: var(--label2-regular-font-weight);
+}
+
+/* 보조 텍스트 (Caption) */
+@utility caption1-bold {
+  font-size: var(--caption1-bold-font-size);
+  line-height: var(--caption1-bold-line-height);
+  font-weight: var(--caption1-bold-font-weight);
+}
+@utility caption1-regular {
+  font-size: var(--caption1-regular-font-size);
+  line-height: var(--caption1-regular-line-height);
+  font-weight: var(--caption1-regular-font-weight);
 }


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약

- Typography Token을 확장했습니다.

<br/>

### ✨ 작업 내용

- 기존 Typography 토큰에는 `title`, `subtitle`, `body`, `label` 정도만 존재하여 큰 제목을 나타내거나 작은 메타 정보를 나타낼 때 서비스 토큰을 사용할 수 없다는 문제점이 있었습니다.
- 기존 토큰을 확장하여 더 큰 계층과 더 작은 계층을 표현할 수 있는 폰트 토큰을 추가하였습니다.
- 네이밍은 `display`, `caption`으로 해주었습니다.

<br/>

### ❗ 참고 사항

- 너무 작은 폰트는 사실상 쓰는 상황이 많지 않을 것 같아 caption1 까지만 해주었습니다.
- title 보다 한 단계 더 큰 계층인 display를 만들어두었는데, 혹시나 더 큰 계층이나 더 작은 계층이 필요하다고 판단되시면 피드백에 남겨주시면 감사하겠습니다.

<br/>

### #️⃣ 연관 이슈

- Close #420