### PR TITLE
💄 (#427)  2026-02-05 QA에서 발견한 개선사항 반영

### DIFF
--- a/src/features/avatar-picker/components/AvatarGrid.tsx
+++ b/src/features/avatar-picker/components/AvatarGrid.tsx
@@ -18,7 +18,7 @@ const AvatarGrid = ({
   selectedBgColor,
 }: AvatarGridProps) => {
   return (
-    <div className="px-10 sm:px-24 sm:py-6 max-h-96 overflow-y-auto">
+    <div className="px-10 py-5 sm:px-24 sm:py-6 max-h-96 overflow-y-auto">
       <div aria-label="아바타 목록" className="grid grid-cols-4 gap-6 sm:gap-8 pt-2 ">
         {avatarList.map((avatarUrl, index) => {
           const isSelected = selectedAvatarId === String(index);

--- a/src/features/avatar-picker/components/AvatarSaveBtn.tsx
+++ b/src/features/avatar-picker/components/AvatarSaveBtn.tsx
@@ -1,19 +1,14 @@
 import { Button } from '@/shared/components/shadcn/button';
+import { ArrowRight } from 'lucide-react';
 interface AvatarSaveBtnProps {
   handleSave: () => void;
 }
 const AvatarSaveBtn = ({ handleSave }: AvatarSaveBtnProps) => {
   return (
-    <div className="pt-12">
-      <Button
-        onClick={handleSave}
-        variant="defaultBoost"
-        className="w-50 sm:w-80 h-14 body1-bold rounded-2xl hover:shadow-lg hover:-translate-y-1 transition"
-        size="lg"
-      >
-        완료
-      </Button>
-    </div>
+    <Button onClick={handleSave} variant="defaultBoost" size="lg">
+      <ArrowRight className="w-5 h-5" />
+      저장하고 다음
+    </Button>
   );
 };
 

--- a/src/features/notifications/components/notificationDropdownMenu/NotificationListItem.tsx
+++ b/src/features/notifications/components/notificationDropdownMenu/NotificationListItem.tsx
@@ -1,6 +1,5 @@
 import { DropdownMenuItem } from '@/shared/components/shadcn/dropdown-menu';
-import { Bell, Check } from 'lucide-react';
-import { Button } from '@/shared/components/shadcn/button';
+import { Bell } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
 import type { NotificationItem } from '@/features/notifications/types/NotificationsType';
 
@@ -15,13 +14,24 @@ const NotificationListItem = ({ notification, onMarkAsRead }: NotificationListIt
   return (
     <DropdownMenuItem
       className={cn(
-        'group relative rounded-xl transition-colors m-1 p-2 sm:p-3 hover:bg-transparent focus:bg-transparent',
+        'group relative rounded-xl transition-colors m-0.5 sm:m-1 p-2 sm:p-3 hover:bg-transparent focus:bg-transparent',
         !n.read && 'bg-blue-50 hover:bg-blue-50 focus:bg-blue-50',
       )}
+      onSelect={(e) => {
+        e.preventDefault();
+        onMarkAsRead(n.id);
+      }}
     >
       <div className="flex gap-2 sm:gap-3 w-full">
-        <div className="flex-shrink-0 w-7 h-7 sm:w-10 sm:h-10 rounded-full flex items-center justify-center bg-blue-100">
-          <Bell className="w-4 h-4 sm:w-5 sm:h-5 text-boost-blue" />
+        <div
+          className={cn(
+            'flex-shrink-0 w-7 h-7 sm:w-10 sm:h-10 rounded-full flex items-center justify-center',
+            n.read ? 'bg-gray-100' : 'bg-blue-100',
+          )}
+        >
+          <Bell
+            className={cn('w-4 h-4 sm:w-5 sm:h-5', n.read ? 'text-gray-400/70' : 'text-boost-blue')}
+          />
         </div>
 
         <div className="flex-1 min-w-0">
@@ -33,11 +43,16 @@ const NotificationListItem = ({ notification, onMarkAsRead }: NotificationListIt
           >
             {n.title}
           </p>
-          <p className={cn('text-xs mb-1 mt-1', n.read ? 'text-gray-500/70' : 'text-gray-700')}>
+          <p
+            className={cn(
+              'caption1-regular mt-1 mb-1 leading-4 h-8 overflow-hidden break-words',
+              n.read ? 'text-gray-500/70' : 'text-gray-700',
+            )}
+          >
             {n.message}
           </p>
 
-          <p className="text-[10px] sm:text-xs text-gray-500/60">
+          <p className="text-[10px] sm:caption1-regular text-gray-500/60">
             {new Date(n.createdAt).toLocaleString('ko-KR', {
               month: 'short',
               day: 'numeric',
@@ -46,20 +61,6 @@ const NotificationListItem = ({ notification, onMarkAsRead }: NotificationListIt
             })}
           </p>
         </div>
-
-        {!n.read && (
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-6 w-6 sm:h-7 sm:w-7 hover:bg-blue-100 cursor-pointer"
-            onClick={(e) => {
-              e.stopPropagation();
-              onMarkAsRead(n.id);
-            }}
-          >
-            <Check className="h-3 w-3 sm:h-4 sm:w-4 text-boost-blue" />
-          </Button>
-        )}
       </div>
     </DropdownMenuItem>
   );

--- a/src/features/notifications/components/notificationDropdownMenu/NotificationLoadMoreButton.tsx
+++ b/src/features/notifications/components/notificationDropdownMenu/NotificationLoadMoreButton.tsx
@@ -1,3 +1,4 @@
+import { ChevronDown } from 'lucide-react';
 import { Button } from '@/shared/components/shadcn/button';
 import InlineLoader from '@/shared/components/ui/loading/InlineLoader';
 
@@ -11,11 +12,16 @@ const NotificationLoadMoreButton = ({ isFetching, onClick }: NotificationLoadMor
     <div className="p-2 border-t border-gray-200">
       <Button
         variant="ghost"
-        className="w-full text-sm text-gray-600 hover:text-gray-900 hover:bg-gray-50"
+        className="w-full justify-center gap-2 !body2-regular hover:text-gray-900 hover:bg-gray-50"
         onClick={onClick}
         disabled={isFetching}
+        aria-busy={isFetching}
       >
-        {isFetching ? <InlineLoader size={4} /> : '더 보기'}
+        <span className="inline-flex h-4 w-4 items-center justify-center">
+          {isFetching ? <InlineLoader size={4} /> : <ChevronDown className="h-4 w-4" />}
+        </span>
+
+        <span>{isFetching ? '불러오는 중…' : '더 보기'}</span>
       </Button>
     </div>
   );

--- a/src/features/settings/components/UserInfoCard.tsx
+++ b/src/features/settings/components/UserInfoCard.tsx
@@ -50,10 +50,10 @@ export const UserInfoCard = ({ member }: UserInfoComponentProps) => {
         onChange={(e) => setNewName(e.target.value)}
         className="w-40 !body2-regular sm:!body1-regular"
       />
-      <Button size="sm" onClick={handleNameSave} disabled={isPending}>
+      <Button size="sm" variant="defaultBoost" onClick={handleNameSave} disabled={isPending}>
         {isPending ? '저장 중...' : '저장'}
       </Button>
-      <Button size="sm" variant="defaultBoost" onClick={handleNameCancel}>
+      <Button size="sm" variant="ghost" onClick={handleNameCancel}>
         취소
       </Button>
     </div>

--- a/src/features/settings/components/UserInfoCard.tsx
+++ b/src/features/settings/components/UserInfoCard.tsx
@@ -53,7 +53,7 @@ export const UserInfoCard = ({ member }: UserInfoComponentProps) => {
       <Button size="sm" onClick={handleNameSave} disabled={isPending}>
         {isPending ? '저장 중...' : '저장'}
       </Button>
-      <Button size="sm" variant="ghost" onClick={handleNameCancel}>
+      <Button size="sm" variant="defaultBoost" onClick={handleNameCancel}>
         취소
       </Button>
     </div>
@@ -81,11 +81,7 @@ export const UserInfoCard = ({ member }: UserInfoComponentProps) => {
         </div>
 
         <div className="flex gap-3">
-          <Button
-            variant="defaultBoost"
-            onClick={openDrawer}
-            className="w-40 justify-center whitespace-nowrap"
-          >
+          <Button variant="defaultBoost" onClick={openDrawer} className="w-40">
             <Pencil className="w-4 h-4" />
             아바타 변경
           </Button>
@@ -93,7 +89,7 @@ export const UserInfoCard = ({ member }: UserInfoComponentProps) => {
             variant="defaultBoost"
             onClick={() => setIsNameEditing(true)}
             disabled={isNameEditing}
-            className="w-40 justify-center whitespace-nowrap"
+            className="w-40"
           >
             <Pencil className="w-4 h-4" />
             이름 변경
@@ -118,11 +114,7 @@ export const UserInfoCard = ({ member }: UserInfoComponentProps) => {
           <div className="w-full flex justify-center min-h-[40px]">{NameArea}</div>
 
           <div className="flex w-full gap-3">
-            <Button
-              variant="defaultBoost"
-              onClick={openDrawer}
-              className="flex-1 justify-center whitespace-nowrap"
-            >
+            <Button variant="defaultBoost" onClick={openDrawer} className="flex-1">
               <Pencil className="w-4 h-4" />
               아바타 변경
             </Button>
@@ -130,7 +122,7 @@ export const UserInfoCard = ({ member }: UserInfoComponentProps) => {
               variant="defaultBoost"
               onClick={() => setIsNameEditing(true)}
               disabled={isNameEditing}
-              className="flex-1 justify-center whitespace-nowrap"
+              className="flex-1"
             >
               <Pencil className="w-4 h-4" />
               이름 변경

--- a/src/features/settings/components/UserInfoCard.tsx
+++ b/src/features/settings/components/UserInfoCard.tsx
@@ -82,14 +82,21 @@ export const UserInfoCard = ({ member }: UserInfoComponentProps) => {
 
         <div className="flex gap-3">
           <Button
-            variant="secondary"
+            variant="defaultBoost"
+            onClick={openDrawer}
+            className="w-40 justify-center whitespace-nowrap"
+          >
+            <Pencil className="w-4 h-4" />
+            아바타 변경
+          </Button>
+          <Button
+            variant="defaultBoost"
             onClick={() => setIsNameEditing(true)}
             disabled={isNameEditing}
+            className="w-40 justify-center whitespace-nowrap"
           >
+            <Pencil className="w-4 h-4" />
             이름 변경
-          </Button>
-          <Button onClick={openDrawer} variant="secondary">
-            아바타 변경
           </Button>
         </div>
       </div>

--- a/src/features/settings/components/UserInfoCard.tsx
+++ b/src/features/settings/components/UserInfoCard.tsx
@@ -48,7 +48,7 @@ export const UserInfoCard = ({ member }: UserInfoComponentProps) => {
       <Input
         value={newName}
         onChange={(e) => setNewName(e.target.value)}
-        className="w-40 !body2-regular sm:body1-regular"
+        className="w-40 !body2-regular sm:!body1-regular"
       />
       <Button size="sm" onClick={handleNameSave} disabled={isPending}>
         {isPending ? '저장 중...' : '저장'}

--- a/src/features/settings/components/UserInfoCard.tsx
+++ b/src/features/settings/components/UserInfoCard.tsx
@@ -7,6 +7,7 @@ import toast from 'react-hot-toast';
 import { useState } from 'react';
 import { SettingsSectionCard } from '@/features/settings/components/SettingsSectionCard';
 import { useAvatarStore } from '@/features/avatar-picker/store/useAvatarStore';
+import { Pencil } from 'lucide-react';
 
 interface UserInfoProps {
   name: string;
@@ -42,44 +43,93 @@ export const UserInfoCard = ({ member }: UserInfoComponentProps) => {
     setIsNameEditing(false);
   };
 
-  return (
-    <SettingsSectionCard title="내 정보">
-      <div className="flex items-center gap-4">
-        <Avatar
-          style={{ backgroundColor: member.backgroundColor }}
-          className="w-15 h-15 sm:w-18 sm:h-18 flex items-center justify-center"
-        >
-          <AvatarImage
-            className="w-12 h-12 sm:w-15 sm:h-15"
-            src={getAvatarSrc(member)}
-            alt="user avatar"
-          />
-          <AvatarFallback>{member.name.charAt(0)}</AvatarFallback>
-        </Avatar>
+  const NameArea = isNameEditing ? (
+    <div className="flex items-center gap-2">
+      <Input
+        value={newName}
+        onChange={(e) => setNewName(e.target.value)}
+        className="w-40 !body2-regular sm:body1-regular"
+      />
+      <Button size="sm" onClick={handleNameSave} disabled={isPending}>
+        {isPending ? '저장 중...' : '저장'}
+      </Button>
+      <Button size="sm" variant="ghost" onClick={handleNameCancel}>
+        취소
+      </Button>
+    </div>
+  ) : (
+    <p className="body2-regular sm:body1-regular">{member.name}</p>
+  );
 
-        {isNameEditing ? (
-          <div className="flex items-center gap-2">
-            <Input value={newName} onChange={(e) => setNewName(e.target.value)} className="w-40" />
-            <Button size="sm" onClick={handleNameSave} disabled={isPending}>
-              {isPending ? '저장 중...' : '저장'}
-            </Button>
-            <Button size="sm" variant="ghost" onClick={handleNameCancel}>
-              취소
-            </Button>
-          </div>
-        ) : (
-          <p className="body2-regular sm:body1-regular">{member.name}</p>
-        )}
+  return (
+    <SettingsSectionCard title="내 정보" desc="아바타와 이름을 변경할 수 있어요.">
+      <div className="hidden sm:flex items-center justify-between gap-6">
+        <div className="flex items-center gap-4">
+          <Avatar
+            style={{ backgroundColor: member.backgroundColor }}
+            className="w-18 h-18 flex items-center justify-center"
+          >
+            <AvatarImage
+              className="w-15 h-15 object-contain"
+              src={getAvatarSrc(member)}
+              alt="user avatar"
+            />
+            <AvatarFallback>{member.name.charAt(0)}</AvatarFallback>
+          </Avatar>
+
+          {NameArea}
+        </div>
+
+        <div className="flex gap-3">
+          <Button
+            variant="secondary"
+            onClick={() => setIsNameEditing(true)}
+            disabled={isNameEditing}
+          >
+            이름 변경
+          </Button>
+          <Button onClick={openDrawer} variant="secondary">
+            아바타 변경
+          </Button>
+        </div>
       </div>
 
-      <div className="flex gap-3">
-        <Button variant="secondary" onClick={() => setIsNameEditing(true)} disabled={isNameEditing}>
-          이름 변경
-        </Button>
+      <div className="sm:hidden">
+        <div className="flex flex-col items-center gap-4 px-3 py-4 bg-gray-200 rounded-lg shadow-sm">
+          <Avatar
+            style={{ backgroundColor: member.backgroundColor }}
+            className="w-20 h-20 flex items-center justify-center"
+          >
+            <AvatarImage
+              className="w-16 h-16 object-contain"
+              src={getAvatarSrc(member)}
+              alt="user avatar"
+            />
+            <AvatarFallback className="text-xl">{member.name.charAt(0)}</AvatarFallback>
+          </Avatar>
 
-        <Button onClick={openDrawer} variant="secondary">
-          아바타 변경
-        </Button>
+          <div className="w-full flex justify-center min-h-[40px]">{NameArea}</div>
+
+          <div className="flex w-full gap-3">
+            <Button
+              variant="defaultBoost"
+              onClick={openDrawer}
+              className="flex-1 justify-center whitespace-nowrap"
+            >
+              <Pencil className="w-4 h-4" />
+              아바타 변경
+            </Button>
+            <Button
+              variant="defaultBoost"
+              onClick={() => setIsNameEditing(true)}
+              disabled={isNameEditing}
+              className="flex-1 justify-center whitespace-nowrap"
+            >
+              <Pencil className="w-4 h-4" />
+              이름 변경
+            </Button>
+          </div>
+        </div>
       </div>
     </SettingsSectionCard>
   );

--- a/src/features/task-detail/components/CommentSection/CommentItem.tsx
+++ b/src/features/task-detail/components/CommentSection/CommentItem.tsx
@@ -7,6 +7,7 @@ import { CommentActionsMenu } from '@/features/task-detail/components/CommentSec
 import { useTaskDetailStore } from '@/features/task-detail/store/useTaskDetailStore';
 import { useShallow } from 'zustand/react/shallow';
 import { AuthorAvatar } from '@/features/task-detail/components/CommentSection/AuthorAvatar';
+import { Pin } from 'lucide-react';
 
 interface CommentItemProps {
   comment: CommentUIType;
@@ -53,7 +54,7 @@ const CommentItem = forwardRef<HTMLDivElement, CommentItemProps>(
             )}
           >
             <div className="flex items-center justify-between pb-2 sm:pb-3">
-              <div className="flex items-center gap-2 sm:gap-3">
+              <div className="flex items-center gap-1 sm:gap-2">
                 <AuthorAvatar
                   persona={comment.persona}
                   isAnonymous={comment.isAnonymous}
@@ -65,10 +66,7 @@ const CommentItem = forwardRef<HTMLDivElement, CommentItemProps>(
                   {isAnonymous ? '익명' : comment.authorInfo.name}
                 </span>
                 {comment.isPinned && (
-                  <span
-                    className="inline-block size-2 rounded-full bg-boost-orange"
-                    aria-label="핀 댓글"
-                  />
+                  <Pin className="size-3 sm:size-4 text-boost-orange" aria-label="핀 댓글" />
                 )}
               </div>
 

--- a/src/features/task-detail/components/CommentSection/CommentItem.tsx
+++ b/src/features/task-detail/components/CommentSection/CommentItem.tsx
@@ -1,5 +1,4 @@
 import { forwardRef } from 'react';
-import { Pin } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
 import type { CommentUIType } from '@/features/comment/types/commentTypes';
 import type { FileInfo } from '@/features/task-detail/types/taskDetailType';
@@ -65,7 +64,12 @@ const CommentItem = forwardRef<HTMLDivElement, CommentItemProps>(
                 <span className="label2-bold sm:label1-bold text-gray-800">
                   {isAnonymous ? '익명' : comment.authorInfo.name}
                 </span>
-                {comment.isPinned && <Pin className="h-3.5 w-3.5 text-boost-blue" />}
+                {comment.isPinned && (
+                  <span
+                    className="inline-block size-2 rounded-full bg-boost-orange"
+                    aria-label="핀 댓글"
+                  />
+                )}
               </div>
 
               <div className="flex items-center gap-1">

--- a/src/pages/AvatarSettingsPage.tsx
+++ b/src/pages/AvatarSettingsPage.tsx
@@ -45,7 +45,7 @@ const AvatarSettingsPage = () => {
           <AvatarSelector />
           <AvatarInfo />
         </div>
-        <div className="pb-30  mx-auto">
+        <div className="flex-1 mx-auto">
           <AvatarSaveBtn handleSave={handleSave} />
         </div>
       </div>


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약
- QR에서 발견된 UX 개선 사항을 반영해 핀 댓글 표시, 알림 드롭다운, 설정 페이지 모바일 UI를 리팩터링했습니다.

### ✨ 작업 내용

#### 1) 핀 댓글 아이콘 개선
- 기존 `<Pin />` 아이콘은 핀이 많을 때 화면이 지저분해 보여, boost-orange 색상의 점(dot) 표시로 변경했습니다.
- 댓글/핀 활성 상태에서도 동일한 주황 톤을 사용해 더 통일감 있게 보이도록 했습니다.
- 이미지 참고 후 의견 부탁드립니다.
<img width="460" height="801" alt="image" src="https://github.com/user-attachments/assets/bfde4a70-ac23-4407-aaea-f8b0f842b01e" />

#### 2) 알림 드롭다운 메뉴 UX 개선
- 기존에는 체크 아이콘을 눌러 읽음 처리하는 방식이었습니다.
- 모바일에서도 더 누르기 쉽도록 알림 아이템 클릭 시 읽음 처리되도록 변경했고, 이에 따라 체크 아이콘을 제거했습니다.
- 알림 메뉴 아래 `더보기` 버튼에 아이콘을 추가했습니다.
<img width="351" height="388" alt="image" src="https://github.com/user-attachments/assets/6e562181-e772-4675-a772-12dc0a2c4c8a" />

#### 3) 설정 페이지 UserInfoCard 모바일 디자인 수정
- 지난 PR에서 다연님이 주셨던 의견 기반 디자인으로 수정했습니다.
<img width="405" height="518" alt="image" src="https://github.com/user-attachments/assets/7e782b5f-4f60-4bc9-9339-014d935a244f" />

#### 4) 기타 QR 개선 사항 반영
- 아바타 그리드 하단 여백 추가
- 아바타 설정 페이지 저장 버튼에 아이콘 추가
<img width="468" height="783" alt="image" src="https://github.com/user-attachments/assets/ee1595b9-1cfc-4ec8-8964-ade842f5249d" />

### ❗ 참고 사항
- 모바일 사용 시 아바타 설정 페이지, 알림 페이지에서 발생하는 스크롤 이슈는 별도 PR로 올리겠습니다!

### #️⃣ 연관 이슈
- Close #427