### PR TITLE
📱 (#418) 프로젝트 페이지 멤버 보드 반응형 도입

### DIFF
--- a/src/features/board/components/MemberBoard/BaseColumnLayout.tsx
+++ b/src/features/board/components/MemberBoard/BaseColumnLayout.tsx
@@ -1,0 +1,89 @@
+import type { ReactNode } from 'react';
+import { motion } from 'framer-motion';
+import { cn } from '@/shared/lib/utils';
+import { Separator } from '@/shared/components/shadcn/separator';
+import { useIsMobile } from '@/shared/hooks/use-mobile';
+import { useColumnCollapsible } from '@/features/board/hooks/useColumnCollapsible';
+
+interface BaseColumnLayoutProps {
+  columnBgColor: string;
+  headerBgColor: string;
+  onScrollBottom?: () => void;
+  headerAvatar: (isCollapsed: boolean) => ReactNode;
+  headerContent: (isCollapsed: boolean) => ReactNode;
+  children: ReactNode;
+  separatorColor?: string;
+}
+
+const BaseColumnLayout = ({
+  columnBgColor,
+  headerBgColor,
+  onScrollBottom,
+  headerAvatar,
+  headerContent,
+  children,
+  separatorColor = 'bg-gray-300',
+}: BaseColumnLayoutProps) => {
+  const isMobile = useIsMobile();
+  const { scrollRef, isProfileCollapsible, handleMouseEnter, handleMouseLeave } =
+    useColumnCollapsible({ onScrollBottom });
+
+  const isCollapsed = isMobile || isProfileCollapsible;
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col m-1 h-full shadow-md rounded-xl border-2 border-gray-300 flex-none w-[calc(100vw-26px)] md:w-[330px] snap-center md:snap-align-none overflow-hidden',
+        columnBgColor,
+      )}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      <motion.div
+        className={cn(
+          'flex items-center gap-10 md:gap-3 justify-center md:justify-between p-3 rounded-t-xl sticky top-0 z-10',
+          headerBgColor,
+        )}
+        animate={{ flexDirection: isCollapsed ? 'row' : 'column' }}
+        transition={{ duration: 0.3, ease: [0.25, 0.1, 0.25, 1] }}
+      >
+        <motion.div
+          className={cn('relative flex items-center mt-6', {
+            'ml-3': isProfileCollapsible,
+          })}
+          animate={{
+            marginTop: isCollapsed ? '0px' : '20px',
+            scale: isCollapsed ? 0.8 : 1,
+          }}
+          transition={{ duration: 0.2, ease: [0.25, 0.1, 0.25, 1] }}
+        >
+          {headerAvatar(isCollapsed)}
+        </motion.div>
+
+        <motion.div
+          className={cn(
+            'flex flex-col',
+            isCollapsed ? 'gap-1 items-start mr-5 mb-2' : 'gap-4 items-center',
+          )}
+          transition={{ duration: 0.2, ease: [0.25, 0.1, 0.25, 1] }}
+        >
+          {headerContent(isCollapsed)}
+        </motion.div>
+      </motion.div>
+
+      <Separator
+        className={cn(
+          'hidden md:block',
+          separatorColor,
+          isProfileCollapsible ? 'my-2' : '!w-3/5 mx-auto my-7',
+        )}
+      />
+
+      <div ref={scrollRef} className="relative flex flex-col p-2 gap-4 overflow-y-auto flex-grow">
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default BaseColumnLayout;

--- a/src/features/board/components/MemberBoard/DoneColumn.tsx
+++ b/src/features/board/components/MemberBoard/DoneColumn.tsx
@@ -1,23 +1,17 @@
 import { motion } from 'framer-motion';
-import { useState } from 'react';
-import type { TaskListItem } from '@/features/task/types/task.domain.types';
-import { useVerticalScroll } from '@/features/board/hooks/useVerticalScroll';
-import TaskCard from '@/features/task/components/TaskCard/TaskCard';
-import doneIcon from '@/shared/assets/images/etc/done.png';
 import { cn } from '@/shared/lib/utils';
+import doneIcon from '@/shared/assets/images/etc/done.png';
 import { Avatar, AvatarImage } from '@/shared/components/shadcn/avatar';
-import { Separator } from '@/shared/components/shadcn/separator';
-import { COLLAPSIBLE_SCROLL_THRESHOLD } from '@/features/board/constants/board.ui.constants';
+import type { TaskListItem } from '@/features/task/types/task.domain.types';
+import TaskCard from '@/features/task/components/TaskCard/TaskCard';
 import { useTagFilterStore } from '@/features/tag/store/useTagFilterStore';
+import BaseColumnLayout from '@/features/board/components/MemberBoard/BaseColumnLayout';
 
 interface DoneColumnProps {
   tasks: TaskListItem[];
 }
 
 const DoneColumn = ({ tasks }: DoneColumnProps) => {
-  const [isProfileCollapsible, setIsProfileCollapsible] = useState(false);
-  const [isMouseInside, setIsMouseInside] = useState(false);
-
   const { selectedTags } = useTagFilterStore();
 
   const filteredTasks =
@@ -27,87 +21,51 @@ const DoneColumn = ({ tasks }: DoneColumnProps) => {
         )
       : tasks;
 
-  const scrollRef = useVerticalScroll<HTMLDivElement>(() => {
-    if (!scrollRef.current || !isMouseInside) return;
-    const { scrollHeight } = scrollRef.current;
-    setIsProfileCollapsible(scrollHeight > COLLAPSIBLE_SCROLL_THRESHOLD);
-  });
-
-  const handleMouseEnter = () => setIsMouseInside(true);
-  const handleMouseLeave = () => {
-    setIsMouseInside(false);
-    setIsProfileCollapsible(false);
-  };
-
   return (
-    <div
-      className="flex flex-col bg-gray-200 m-1 shadow-md rounded-xl border-2 border-gray-300 w-[330px] overflow-hidden"
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-    >
-      <motion.div
-        className="flex items-center gap-3 justify-between p-3 rounded-t-xl sticky top-0 bg-gray-200 z-10"
-        animate={{ flexDirection: isProfileCollapsible ? 'row' : 'column' }}
-        transition={{ duration: 0.3, ease: [0.25, 0.1, 0.25, 1] }}
-      >
-        <motion.div
-          className={cn('flex items-center mt-5', { 'ml-3': isProfileCollapsible })}
-          animate={{
-            marginTop: isProfileCollapsible ? '0px' : '20px',
-            scale: isProfileCollapsible ? 0.8 : 1,
-          }}
-          transition={{ duration: 0.2, ease: [0.25, 0.1, 0.25, 1] }}
+    <BaseColumnLayout
+      columnBgColor="bg-gray-100"
+      headerBgColor="bg-gray-200"
+      separatorColor="bg-gray-400"
+      headerAvatar={(isProfileCollapsible) => (
+        <Avatar
+          className={cn(
+            'items-center justify-center',
+            isProfileCollapsible ? 'w-23 h-23' : 'w-27 h-27',
+          )}
         >
-          <Avatar
-            className={cn(
-              'flex items-center justify-center',
-              isProfileCollapsible ? 'w-23 h-23' : 'w-27 h-27',
-            )}
-          >
-            <AvatarImage
-              src={doneIcon}
-              className={cn(isProfileCollapsible ? 'w-20 h-20' : 'w-22 h-22')}
-            />
-          </Avatar>
-        </motion.div>
-
+          <AvatarImage
+            src={doneIcon}
+            className={cn(isProfileCollapsible ? 'w-20 h-20' : 'w-22 h-22')}
+          />
+        </Avatar>
+      )}
+      headerContent={(isProfileCollapsible) => (
         <motion.div
           className={cn(
-            'flex flex-col',
+            'flex flex-row md:flex-col',
             isProfileCollapsible ? 'gap-1 items-start' : 'gap-4 items-center',
           )}
-          animate={{
-            x: isProfileCollapsible ? -20 : 0,
-            y: isProfileCollapsible ? -4 : 0,
-          }}
+          animate={{ x: isProfileCollapsible ? -20 : 0, y: isProfileCollapsible ? -4 : 0 }}
           transition={{ duration: 0.2, ease: [0.25, 0.1, 0.25, 1] }}
         >
           <div
             className={cn('items-center title1-bold mt-2 text-gray-600', {
-              'mr-18': isProfileCollapsible,
+              'mr-10 md:mr-18': isProfileCollapsible,
             })}
           >
             진행 완료
           </div>
 
-          <div className="flex justify-center items-center bg-gray-300 px-2 py-1 text-sm rounded-md w-fit">
+          <div className="flex justify-center items-center mt-2 md:mt-0 bg-gray-300 px-2 py-1 label1-regular rounded-md w-fit">
             {filteredTasks.length}
           </div>
         </motion.div>
-      </motion.div>
-
-      <Separator
-        className={cn(
-          isProfileCollapsible ? 'my-2 bg-gray-300' : 'bg-gray-400 !w-3/5 mx-auto my-7',
-        )}
-      />
-
-      <div ref={scrollRef} className="relative flex flex-col p-2 gap-4 overflow-y-auto flex-grow">
-        {filteredTasks.map((task) => (
-          <TaskCard key={task.taskId} task={task} draggable={false} />
-        ))}
-      </div>
-    </div>
+      )}
+    >
+      {filteredTasks.map((task) => (
+        <TaskCard key={task.taskId} task={task} draggable={false} />
+      ))}
+    </BaseColumnLayout>
   );
 };
 

--- a/src/features/board/components/MemberBoard/MemberBoard.tsx
+++ b/src/features/board/components/MemberBoard/MemberBoard.tsx
@@ -19,6 +19,7 @@ interface MemberBoardProps {
 
 const MemberBoard = ({ projectId }: MemberBoardProps) => {
   const [isBoardHover, setIsBoardHover] = useState(false);
+  const [currentIndex, setCurrentIndex] = useState(0);
 
   const {
     ref: scrollRef,
@@ -52,6 +53,14 @@ const MemberBoard = ({ projectId }: MemberBoardProps) => {
   );
   const doneTasks: TaskListItem[] = doneData?.pages.flatMap((page) => page.tasks) ?? [];
 
+  const onScroll = () => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setCurrentIndex(Math.round(el.scrollLeft / el.clientWidth));
+  };
+
+  const totalColumnsCount = sortedMembersWithBoosting.length + 1;
+
   const handleMouseEnter = () => setIsBoardHover(true);
   const handleMouseLeave = () => setIsBoardHover(false);
 
@@ -61,14 +70,28 @@ const MemberBoard = ({ projectId }: MemberBoardProps) => {
 
   return (
     <div
-      className="relative w-full h-full"
+      className="relative w-full h-full flex flex-col"
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >
-      {/* 가로 스크롤 버튼 */}
+      {/* 인디케이터 (모바일용)*/}
+      <div className="flex justify-center gap-2 pt-3.5 py-2 shrink-0 md:hidden">
+        {Array.from({ length: totalColumnsCount }).map((_, idx) => (
+          <div
+            key={idx}
+            className="h-2 rounded-full bg-gray-400 transition-[width, background-color] duration-300 ease-out"
+            style={{
+              width: idx === currentIndex ? 24 : 8,
+              opacity: idx === currentIndex ? 1 : 0.5,
+            }}
+          />
+        ))}
+      </div>
+
+      {/* 가로 스크롤 버튼 (데스크탑용) */}
       {isBoardHover && canScrollLeft && (
         <>
-          <div className="pointer-events-none fixed ml-[75px] left-0 h-[calc(100%-152px)] w-16 z-40 bg-gradient-to-r from-gray-300/90 to-transparent" />
+          <div className="hidden md:block pointer-events-none fixed ml-[75px] left-0 h-[calc(100%-152px)] w-16 z-40 bg-gradient-to-r from-gray-300/90 to-transparent" />
           <button
             onClick={() => scroll('left')}
             className="fixed ml-18 mt-18 left-4 top-1/2 transform -translate-y-1/2 z-50 p-2 bg-gray-300/70 hover:bg-gray-300 rounded-full shadow-md"
@@ -79,7 +102,7 @@ const MemberBoard = ({ projectId }: MemberBoardProps) => {
       )}
       {isBoardHover && canScrollRight && (
         <>
-          <div className="pointer-events-none fixed right-0 h-[calc(100%-152px)] w-16 z-40 bg-gradient-to-l from-gray-400/60 to-transparent" />
+          <div className="hidden md:block pointer-events-none fixed right-0 h-[calc(100%-152px)] w-16 z-40 bg-gradient-to-l from-gray-400/60 to-transparent" />
           <button
             onClick={() => scroll('right')}
             className="fixed mr-2 mt-18 right-4 top-1/2 transform -translate-y-1/2 z-50 p-2 bg-gray-300/70 hover:bg-gray-300 rounded-full shadow-md"
@@ -89,8 +112,11 @@ const MemberBoard = ({ projectId }: MemberBoardProps) => {
         </>
       )}
 
-      {/* 멤버 컬럼 */}
-      <div ref={scrollRef} className="overflow-x-auto overflow-y-hidden h-full py-2 px-1">
+      <div
+        ref={scrollRef}
+        onScroll={onScroll}
+        className="flex flex-nowrap flex-grow overflow-x-auto overflow-y-hidden items-stretch scroll-smooth snap-x snap-mandatory md:snap-none h-full pb-4 px-2"
+      >
         <div className="flex gap-3 min-w-max h-full items-stretch">
           {(sortedMembersWithBoosting ?? []).map((member: MemberWithBoosting) => (
             <MemberColumn
@@ -101,7 +127,6 @@ const MemberBoard = ({ projectId }: MemberBoardProps) => {
             />
           ))}
 
-          {/* 완료 컬럼 */}
           <DoneColumn tasks={doneTasks} />
         </div>
       </div>

--- a/src/features/board/components/MemberBoard/MemberBoard.tsx
+++ b/src/features/board/components/MemberBoard/MemberBoard.tsx
@@ -115,7 +115,7 @@ const MemberBoard = ({ projectId }: MemberBoardProps) => {
       <div
         ref={scrollRef}
         onScroll={onScroll}
-        className="flex flex-nowrap flex-grow overflow-x-auto overflow-y-hidden items-stretch scroll-smooth snap-x snap-mandatory md:snap-none h-full pb-4 px-2"
+        className="flex flex-nowrap flex-grow overflow-x-auto overflow-y-hidden items-stretch scroll-smooth snap-x snap-mandatory md:snap-none h-full md:pt-2 pb-4 px-2"
       >
         <div className="flex gap-3 min-w-max h-full items-stretch">
           {(sortedMembersWithBoosting ?? []).map((member: MemberWithBoosting) => (

--- a/src/features/board/components/MemberBoard/MemberColumn.tsx
+++ b/src/features/board/components/MemberBoard/MemberColumn.tsx
@@ -1,14 +1,10 @@
-import { useState } from 'react';
 import { motion } from 'framer-motion';
 import { cn } from '@/shared/lib/utils';
 import { useInfiniteProjectTasksByMemberQuery } from '@/features/task/hooks/query/useInfiniteProjectTasksByMemberQuery';
-import { useVerticalScroll } from '@/features/board/hooks/useVerticalScroll';
 import TaskCard from '@/features/task/components/TaskCard/TaskCard';
 import { Avatar, AvatarFallback, AvatarImage } from '@/shared/components/shadcn/avatar';
-import { Separator } from '@/shared/components/shadcn/separator';
 import rocket from '@/shared/assets/images/boost/rocket-2d.png';
 import { COLUMN_ORDER } from '@/features/board/constants/board.domain.constants';
-import { COLLAPSIBLE_SCROLL_THRESHOLD } from '@/features/board/constants/board.ui.constants';
 import { useProjectTaskCountByMemberQuery } from '@/features/task/hooks/query/useProjectTaskCountByMemberQuery';
 import { getTaskCountByMember } from '@/features/task/utils/taskUtils';
 import { getAvatarSrc } from '@/features/avatar-picker/utils/avatarUtils';
@@ -20,6 +16,7 @@ import { useTagFilterStore } from '@/features/tag/store/useTagFilterStore';
 import InlineLoader from '@/shared/components/ui/loading/InlineLoader';
 import { TASK_STATUS, TASK_STATUS_META } from '@/features/task/constants/task.domain.constants';
 import type { TaskListItem } from '@/features/task/types/task.domain.types';
+import BaseColumnLayout from '@/features/board/components/MemberBoard/BaseColumnLayout';
 
 interface MemberColumnProps {
   projectId: string;
@@ -28,8 +25,6 @@ interface MemberColumnProps {
 }
 
 const MemberColumn = ({ projectId, member, isAllScoreZero }: MemberColumnProps) => {
-  const [isProfileCollapsible, setIsProfileCollapsible] = useState(false);
-  const [isMouseInside, setIsMouseInside] = useState(false);
   const currentUser = useAuthStore((state) => state.user);
   const { selectedTags } = useTagFilterStore();
 
@@ -63,41 +58,15 @@ const MemberColumn = ({ projectId, member, isAllScoreZero }: MemberColumnProps) 
     tasks: filteredActiveTasks.filter((t) => t.status === status),
   }));
 
-  const scrollRef = useVerticalScroll<HTMLDivElement>(() => {
-    if (!scrollRef.current || !isMouseInside) return;
-    const { scrollTop, scrollHeight, clientHeight } = scrollRef.current;
-    setIsProfileCollapsible(scrollHeight > COLLAPSIBLE_SCROLL_THRESHOLD);
-
-    const isAtBottom = scrollTop + clientHeight >= scrollHeight - 1;
-    if (isAtBottom && hasNextPage && !isFetchingNextPage) fetchNextPage();
-  });
-
-  const handleMouseEnter = () => setIsMouseInside(true);
-  const handleMouseLeave = () => {
-    setIsMouseInside(false);
-    setIsProfileCollapsible(false);
-  };
-
   return (
-    <div
-      className="flex bg-gray-100 m-1 h-full shadow-md rounded-xl border-2 border-gray-300 flex-col w-[330px] overflow-hidden"
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-    >
-      {/* 프로필 영역 */}
-      <motion.div
-        className="flex items-center gap-3 justify-between p-3 rounded-t-xl sticky top-0 bg-gray-100 z-10"
-        animate={{ flexDirection: isProfileCollapsible ? 'row' : 'column' }}
-        transition={{ duration: 0.3, ease: [0.25, 0.1, 0.25, 1] }}
-      >
-        <motion.div
-          className={cn('relative flex items-center mt-6', { 'ml-[12px]': isProfileCollapsible })}
-          animate={{
-            marginTop: isProfileCollapsible ? '0px' : '20px',
-            scale: isProfileCollapsible ? 0.8 : 1,
-          }}
-          transition={{ duration: 0.2, ease: [0.25, 0.1, 0.25, 1] }}
-        >
+    <BaseColumnLayout
+      columnBgColor="bg-gray-100"
+      headerBgColor="bg-gray-100"
+      onScrollBottom={() => {
+        if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+      }}
+      headerAvatar={(isProfileCollapsible) => (
+        <>
           {member.rank === 1 && !isAllScoreZero && (
             <motion.img
               src={Crown}
@@ -112,7 +81,7 @@ const MemberColumn = ({ projectId, member, isAllScoreZero }: MemberColumnProps) 
           )}
           <Avatar
             className={cn(
-              'flex items-center justify-center shadow-sm',
+              'items-center justify-center shadow-sm',
               isProfileCollapsible ? 'w-23 h-23' : 'w-27 h-27',
             )}
             style={{ backgroundColor: member.backgroundColor }}
@@ -123,21 +92,19 @@ const MemberColumn = ({ projectId, member, isAllScoreZero }: MemberColumnProps) 
               className={cn(isProfileCollapsible ? 'w-20 h-20' : 'w-22 h-22')}
             />
           </Avatar>
-        </motion.div>
-
-        <motion.div
-          className={cn(
-            'flex flex-col',
-            isProfileCollapsible ? 'gap-1 items-start mr-5 mb-2' : 'gap-4 items-center',
-          )}
-        >
+        </>
+      )}
+      headerContent={(isProfileCollapsible) => (
+        <>
           <div className={cn(isProfileCollapsible ? 'title2-bold ml-1.5' : 'title1-bold')}>
             {member.name}
           </div>
           <div
             className={cn(
               'flex flex-row items-center gap-1 bg-red-400 rounded-full text-gray-100',
-              isProfileCollapsible ? 'px-1 pr-3 py-0.5 text-xs' : 'px-2 pr-4 py-1 text-sm',
+              isProfileCollapsible
+                ? 'px-1 pr-3 py-0.5 caption1-regular'
+                : 'px-2 pr-4 py-1 label2-regular',
             )}
           >
             <img
@@ -147,41 +114,33 @@ const MemberColumn = ({ projectId, member, isAllScoreZero }: MemberColumnProps) 
             />
             <strong className="mr-1">BOOSTING SCORE</strong>
             {member.totalScore}
-
             {member.id === currentUser?.id && !isProfileCollapsible && (
               <BoostingScoreInfoCard calculatedAt={member.calculatedAt} />
             )}
           </div>
-        </motion.div>
-      </motion.div>
-
-      <Separator
-        className={cn('bg-gray-300', isProfileCollapsible ? 'my-2' : '!w-3/5 mx-auto my-7')}
-      />
-
-      {/* Task 목록 영역 */}
-      <div ref={scrollRef} className="flex flex-col p-2 gap-4 overflow-y-auto flex-grow">
-        {columnData.map(({ status, title, tasks: filteredTasks }) => (
-          <div key={status} className="bg-gray-100 p-2 border-b-1 border-gray-300">
-            <div className="flex flex-row items-center">
-              <div className="label1-regular text-gray-500 m-2">{title}</div>
-              <div className="flex justify-center items-center bg-gray-300 px-2 py-1 text-sm rounded-md w-6 h-6">
-                {selectedTags.length > 0
-                  ? filteredTasks.length
-                  : getTaskCountByMember(status, memberTaskCountList)}
-              </div>
-            </div>
-
-            <div className="flex flex-col gap-2">
-              {filteredTasks.map((task) => (
-                <TaskCard key={task.taskId} task={task} draggable={false} />
-              ))}
+        </>
+      )}
+    >
+      {columnData.map(({ status, title, tasks: filteredTasks }) => (
+        <div key={status} className="bg-gray-100 p-2 border-b-1 border-gray-300">
+          <div className="flex flex-row items-center">
+            <div className="label1-regular text-gray-500 m-2">{title}</div>
+            <div className="flex justify-center items-center bg-gray-300 px-2 py-1 label2-regular rounded-md w-6 h-6">
+              {selectedTags.length > 0
+                ? filteredTasks.length
+                : getTaskCountByMember(status, memberTaskCountList)}
             </div>
           </div>
-        ))}
-        {isFetchingNextPage && <InlineLoader size={5} />}
-      </div>
-    </div>
+
+          <div className="flex flex-col gap-2">
+            {filteredTasks.map((task) => (
+              <TaskCard key={task.taskId} task={task} draggable={false} />
+            ))}
+          </div>
+        </div>
+      ))}
+      {isFetchingNextPage && <InlineLoader size={5} />}
+    </BaseColumnLayout>
   );
 };
 

--- a/src/features/board/hooks/useColumnCollapsible.ts
+++ b/src/features/board/hooks/useColumnCollapsible.ts
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+import { useVerticalScroll } from '@/features/board/hooks/useVerticalScroll';
+import { COLLAPSIBLE_SCROLL_THRESHOLD } from '@/features/board/constants/board.ui.constants';
+
+interface UseColumnCollapsibleProps {
+  onScrollBottom?: () => void;
+}
+
+export const useColumnCollapsible = ({ onScrollBottom }: UseColumnCollapsibleProps) => {
+  const [isProfileCollapsible, setIsProfileCollapsible] = useState(false);
+  const [isMouseInside, setIsMouseInside] = useState(false);
+
+  const scrollRef = useVerticalScroll<HTMLDivElement>(() => {
+    if (!scrollRef.current || !isMouseInside) return;
+
+    const { scrollTop, scrollHeight, clientHeight } = scrollRef.current;
+
+    setIsProfileCollapsible(scrollHeight > COLLAPSIBLE_SCROLL_THRESHOLD);
+
+    if (onScrollBottom) {
+      const isAtBottom = scrollTop + clientHeight >= scrollHeight - 1;
+      if (isAtBottom) {
+        onScrollBottom();
+      }
+    }
+  });
+
+  const handleMouseEnter = () => setIsMouseInside(true);
+  const handleMouseLeave = () => {
+    setIsMouseInside(false);
+    setIsProfileCollapsible(false);
+  };
+
+  return {
+    scrollRef,
+    isProfileCollapsible,
+    handleMouseEnter,
+    handleMouseLeave,
+  };
+};


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약

- 프로젝트 페이지의 멤버 보드에 반응형을 도입했습니다.

<br/>

### ✨ 작업 내용

#### 1. `useColumnCollapsible` 훅 생성
- Done 컬럼과 Member 컬럼에서 공통적으로 사용되는 프로필 Collapsible 로직을 훅으로 분리했습니다.

<br/>

#### 2. `BaseColumnLayout` 컴포넌트 생성
- Done 컬럼과 Member 컬럼에서 공통적인 Layout을 BaseColumnLayout으로 분리했습니다.
- 이 컴포넌트에 멤버 보드 반응형 도입 해주었습니다.

<br/>

#### 3. Done Column과 Member Column에 분리한 훅과 레이아웃 적용
- 1, 2에서 작업한 훅과 레이아웃을 컬럼에 적용해주었습니다.

<br/>

#### 4. 프로젝트 페이지 멤버 보드 반응형 도입
- 반응형이 도입된 Layout을 컬럼들에 적용해주고, 추가 반응형 디자인을 적용해주었습니다.
- 이전에 작업했던 프로젝트 페이지 상태 보드와 동일한 형식으로 반응형을 디자인했습니다.
   - 한 화면에 컬럼 1개씩 보여주고 스와이프 + 스냅 형식의 보드
   - 상단에 인디케이터 추가
 
<br/>

#### 5. 프로젝트 페이지 멤버 보드 반응형 영상 첨부

https://github.com/user-attachments/assets/8c02e30a-3c86-42f4-ab70-1e9ef7f2a86a

https://github.com/user-attachments/assets/27502998-ad9b-4c57-9111-83dfd57b872a


<br/>




### ❗ 참고 사항(선택)

- X

<br/>

### #️⃣ 연관 이슈

- Close #418 
