### PR TITLE
♻️ 2026-03-05 QA에서 발견한 개선사항 반영 (칸반보드 관련 사항 제외)

### DIFF
--- a/src/features/board/components/MemberBoard/DoneColumn.tsx
+++ b/src/features/board/components/MemberBoard/DoneColumn.tsx
@@ -49,14 +49,14 @@ const DoneColumn = ({ tasks }: DoneColumnProps) => {
           transition={{ duration: 0.2, ease: [0.25, 0.1, 0.25, 1] }}
         >
           <div
-            className={cn('items-center title1-bold mt-2 text-gray-600', {
+            className={cn('items-center title2-bold md:title1-bold mt-4 md:mt-0', {
               'mr-10 md:mr-18': isProfileCollapsible,
             })}
           >
             진행 완료
           </div>
 
-          <div className="flex justify-center items-center mt-2 md:mt-0 bg-gray-300 px-2 py-1 label1-regular rounded-md w-fit">
+          <div className="flex justify-center items-center mt-4 md:mt-0 bg-gray-300 px-2 py-1 label1-regular rounded-md w-fit">
             {filteredTasks.length}
           </div>
         </motion.div>

--- a/src/features/file/components/FileTableEmpty.tsx
+++ b/src/features/file/components/FileTableEmpty.tsx
@@ -3,8 +3,8 @@ import { TableRow, TableCell } from '@/shared/components/shadcn/table';
 const FileTableEmpty = () => {
   return (
     <TableRow>
-      <TableCell colSpan={6} className="py-16 text-center text-gray-400">
-        <div className="flex flex-col items-center justify-center">
+      <TableCell colSpan={6}>
+        <div className="flex flex-col items-center justify-center text-gray-400 h-64">
           <div className="text-4xl mb-2">📄</div>
           <div className="body1-regular">파일이 존재하지 않아요!</div>
         </div>

--- a/src/features/memo/components/MemoList/MemoTable.tsx
+++ b/src/features/memo/components/MemoList/MemoTable.tsx
@@ -46,7 +46,7 @@ const MemoTable = ({
               <Checkbox
                 checked={isAllSelected}
                 onCheckedChange={onSelectAll}
-                className="rounded-md"
+                className="data-[state=checked]:bg-boost-blue data-[state=checked]:border-boost-blue"
               />
             </TableHead>
             <TableHead className={cn('w-[80px]')}>번호</TableHead>

--- a/src/features/memo/components/MemoList/MemoTable.tsx
+++ b/src/features/memo/components/MemoList/MemoTable.tsx
@@ -42,14 +42,14 @@ const MemoTable = ({
       <Table className="min-w-full table-fixed border-collapse">
         <TableHeader className="sticky top-0 z-10 bg-white text-gray-800 subtitle2-bold">
           <TableRow className="border-b border-gray-300 h-12 hover:bg-white">
-            <TableHead className="w-[60px] px-5">
+            <TableHead className="w-[50px] md:w-[60px] px-5">
               <Checkbox
                 checked={isAllSelected}
                 onCheckedChange={onSelectAll}
                 className="data-[state=checked]:bg-boost-blue data-[state=checked]:border-boost-blue"
               />
             </TableHead>
-            <TableHead className={cn('w-[80px]')}>번호</TableHead>
+            <TableHead className="w-[50px] md:w-[80px]">번호</TableHead>
             <TableHead>제목</TableHead>
             <TableHead className={cn('w-[200px]', mobileHiddenClass)}>생성일</TableHead>
             <TableHead className={cn('w-[200px]', mobileHiddenClass)}>수정일</TableHead>

--- a/src/features/memo/components/MemoList/MemoTableRow.tsx
+++ b/src/features/memo/components/MemoList/MemoTableRow.tsx
@@ -54,7 +54,7 @@ const MemoTableRow = ({
           checked={selected}
           onCheckedChange={handleSelectRow}
           onClick={(e) => e.stopPropagation()}
-          className="rounded-md"
+          className="data-[state=checked]:bg-boost-blue data-[state=checked]:border-boost-blue"
         />
       </TableCell>
 

--- a/src/features/project/components/ProjectMembersList.tsx
+++ b/src/features/project/components/ProjectMembersList.tsx
@@ -7,7 +7,7 @@ interface ProjectMembersListProps {
 
 const ProjectMembersList = ({ members }: ProjectMembersListProps) => {
   return (
-    <div className="flex-1.5 overflow-y-auto overflow-x-hidden border-r border-gray-300">
+    <div className="flex-1.5 overflow-y-auto overflow-x-hidden md:border-r border-gray-300">
       <div className="space-y-2 min-w-[220px] md:min-w-[260px] lg:min-w-[320px]">
         <p className="md:hidden label1-bold pl-2">프로젝트 멤버</p>
         {members.map((member) => (

--- a/src/features/task/components/TaskCard/TaskCard.tsx
+++ b/src/features/task/components/TaskCard/TaskCard.tsx
@@ -76,7 +76,7 @@ const TaskCard = forwardRef<HTMLDivElement, TaskCardProps>(
         {...attributes}
         {...listeners}
         className={cn(
-          'bg-gray-100 flex-shrink-0 shadow-sm p-3 min-h-[150px] flex flex-col rounded-2xl border border-gray-200 transition-shadow relative group',
+          'bg-gray-100 flex-shrink-0 shadow-sm p-3 min-h-[150px] flex flex-col rounded-2xl border border-gray-200 transition-shadow relative group select-none',
           'hover:shadow-md',
           draggable ? 'cursor-grab' : 'cursor-default',
         )}


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약

- 2026-03-05 QA에서 발견한 개선사항을 반영했습니다.

<br/><br/>

### ✨ 작업 내용

#### 1. 프로젝트 관리/정보 모달 디자인 오류 수정
- 모바일에서 프로젝트 관리/정보 모달 속 멤버 섹션에 불필요한 border right가 존재하여 모바일에서는 보이지않도록 처리했습니다.
<img width="300" alt="image" src="https://github.com/user-attachments/assets/01c44169-527f-49d9-a07a-b35f109a6983" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/920e66b1-8617-4bca-a1cb-d43605406483" />


<br/>

#### 2. 할 일 카드 디자인 오류 수정
- 할 일 카드에 text focus 잡히지 않도록 처리를 추가했습니다.
- 드래그 중이지 않을 때에도, 드래그 중일 때에도 text focus가 잡히지 않도록 했습니다.

<br/>

#### 3. 메모 목록 / 파일 목록 통일감 처리
- 파일 목록과 메모 목록에서 아무것도 존재하지 않을 때 UI를 통일했습니다.
- 메모 목록도 파일 목록과 유사하게 번호와 제목 사이의 gap을 조절했습니다.
<img width="300" alt="image" src="https://github.com/user-attachments/assets/e824753d-16d6-4f3a-91b3-de4875790436" />

<br/>

#### 4. 메모 목록 체크 박스 디자인 개선
- 기존 shadcn default 색상으로 되어있었던 것을 서비스 색상을 사용하여 개선했습니다.
<img width="300" alt="image" src="https://github.com/user-attachments/assets/a1348c56-c396-45e6-a6cd-bf63fa5329eb" />


<br/>

#### 5. 모바일 팀원보드 디자인 개선
- 진행 완료 text가 크다고 하셔서 모바일일 때에는 title2-bold를 사용했습니다.
- 텍스트 색상도 gray-600 에서 기본 (black)으로 나타나도록 했습니다.
<img width="300" alt="image" src="https://github.com/user-attachments/assets/38b1c3df-7d3e-45ca-823a-64181a0705e0" />

<br/><br/>

### ❗ 참고 사항

- 칸반보드는 태블릿 반응형 도입, 컬럼 전환 오류 수정, 렌더링 깜빡임 문제 등 중요 개선사항 및 버그가 있어 따로 작업하여 PR 올리도록 하겠습니다.

<br/><br/>

### #️⃣ 연관 이슈

- Close #438, #464, #462, #460, #459, #458