### PR TITLE
♻️ 2026-03-05 QA에서 발견한 개선사항 반영

### DIFF
--- a/src/features/avatar-picker/components/AvatarInfo.tsx
+++ b/src/features/avatar-picker/components/AvatarInfo.tsx
@@ -1,10 +1,10 @@
 const AvatarInfo = () => {
   return (
-    <div className="mb-8 pt-10 text-center sm:pt-8">
+    <div className="mb-8 pt-6 text-center sm:pt-8">
       <p className="body2-regular text-gray-600 sm:body1-regular">
         아바타는 언제든지 변경할 수 있으며,
       </p>
-      <p className="mt-1 body2-regular text-gray-600 sm:body1-regular">
+      <p className="sm:mt-1 body2-regular text-gray-600 sm:body1-regular">
         프로필과 댓글에 사용됩니다.
       </p>
     </div>

--- a/src/features/avatar-picker/components/AvatarSelector.tsx
+++ b/src/features/avatar-picker/components/AvatarSelector.tsx
@@ -3,7 +3,7 @@ import AvatarsDrawer from '@/features/avatar-picker/components/AvatarsDrawer';
 
 const AvatarSelector = () => {
   return (
-    <div className="flex flex-col items-center space-y-6 pt-10">
+    <div className="flex flex-col items-center space-y-6 pt-6 sm:pt-10">
       <div className="relative group">
         <div className="absolute inset-0 bg-gradient-to-r from-boost-orange via-boost-blue to-purple-500 rounded-full blur-lg opacity-20 group-hover:opacity-30 transition-opacity duration-300 scale-110" />
         <CurrentAvatar />

--- a/src/features/settings/components/UserInfoCard.tsx
+++ b/src/features/settings/components/UserInfoCard.tsx
@@ -53,7 +53,7 @@ export const UserInfoCard = ({ member }: UserInfoComponentProps) => {
       <Button size="sm" variant="defaultBoost" onClick={handleNameSave} disabled={isPending}>
         {isPending ? '저장 중...' : '저장'}
       </Button>
-      <Button size="sm" variant="ghost" onClick={handleNameCancel}>
+      <Button size="sm" variant="outline" onClick={handleNameCancel}>
         취소
       </Button>
     </div>

--- a/src/features/task-detail/components/CommentSection/CommentEditor/CommentEditorInput.tsx
+++ b/src/features/task-detail/components/CommentSection/CommentEditor/CommentEditorInput.tsx
@@ -23,7 +23,7 @@ const CommentEditorInput = ({
   return (
     <div className="flex items-center gap-2 mb-4 sm:mb-2">
       <Textarea
-        className="rounded-xl !label2-regular sm:!label1-regular focus:ring-transparent flex-1 h-10 resize-none"
+        className="rounded-xl sm:!label1-regular focus:ring-transparent flex-1 h-10 resize-none"
         placeholder={isEditing ? '댓글 수정중..' : '댓글을 입력해주세요'}
         value={input}
         onChange={(e) => setInput(e.target.value)}

--- a/src/features/task-detail/components/CommentSection/CommentList/CommentItem.tsx
+++ b/src/features/task-detail/components/CommentSection/CommentList/CommentItem.tsx
@@ -79,7 +79,7 @@ const CommentItem = forwardRef<HTMLDivElement, CommentItemProps>(
                   name={comment.authorInfo.name}
                 />
 
-                <span className="label2-bold sm:label1-bold text-gray-800 ">
+                <span className="label1-bold sm:body2-bold text-gray-800 ">
                   {isAnonymous ? '익명' : comment.authorInfo.name}
                 </span>
 
@@ -102,7 +102,7 @@ const CommentItem = forwardRef<HTMLDivElement, CommentItemProps>(
               </div>
             </div>
 
-            <p className="px-1 sm:px-2 label2-regular sm:label1-regular text-gray-800">
+            <p className="px-1 sm:px-2 label1-regular sm:body2-regular text-gray-800">
               {comment.content}
             </p>
           </div>

--- a/src/features/task-detail/components/FileSection/FileItem.tsx
+++ b/src/features/task-detail/components/FileSection/FileItem.tsx
@@ -50,10 +50,10 @@ const FileItem = ({
       <div>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <EllipsisVertical className="mt-1 w-4 h-4 sm:w-5 sm:h-5 text-gray-700 " />
+            <EllipsisVertical className="mt-1 w-4 h-4 sm:w-5 sm:h-5 text-gray-700" />
           </DropdownMenuTrigger>
           <DropdownMenuContent
-            className="w-30 sm:w-40 bg-white dark:bg-gray-800 rounded-lg shadow-lg py-1 z-50 border border-gray-200"
+            className="w-30 sm:w-40 bg-white rounded-lg shadow-lg py-1 z-50 border border-gray-200"
             align="end"
           >
             <DropdownMenuGroup>
@@ -62,7 +62,7 @@ const FileItem = ({
                   e.stopPropagation();
                   downloadFile({ fileId, fileName });
                 }}
-                className="px-4 py-2 !label2-regular sm:!label1-regular text-gray-800 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer rounded-md"
+                className="px-4 py-2 !label2-regular sm:!label1-regular text-gray-800 hover:bg-gray-200 cursor-pointer"
               >
                 다운로드
               </DropdownMenuItem>
@@ -71,7 +71,7 @@ const FileItem = ({
                   e.stopPropagation();
                   if (onDelete) onDelete();
                 }}
-                className="px-4 py-2 !label2-regular sm:!label1-regular text-red-800 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer rounded-md"
+                className="px-4 py-2 !label2-regular sm:!label1-regular text-red-600 hover:bg-gray-200 cursor-pointer"
               >
                 삭제
               </DropdownMenuItem>

--- a/src/features/task-detail/components/TaskDetailTopTab/PinCommentTooltip.tsx
+++ b/src/features/task-detail/components/TaskDetailTopTab/PinCommentTooltip.tsx
@@ -22,8 +22,8 @@ const PinCommentTooltip = ({ hintOpen, onOpenComments, currentPin }: PinCommentT
             <MessageSquare className="size-5 transition-colors text-black" />
             {currentPin && (
               <span className="absolute top-2 right-2 flex h-2 w-2">
-                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-gray-900 opacity-75"></span>
-                <span className="relative inline-flex rounded-full h-2 w-2 bg-gray-900"></span>
+                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-gray-900 opacity-75" />
+                <span className="relative inline-flex rounded-full h-2 w-2 bg-gray-900" />
               </span>
             )}
           </Button>

--- a/src/features/task-detail/components/TaskDetailTopTab/PinCommentTooltip.tsx
+++ b/src/features/task-detail/components/TaskDetailTopTab/PinCommentTooltip.tsx
@@ -1,0 +1,39 @@
+import type { PinWithAuthor } from '@/features/task-detail/types/taskDetailType';
+import { Button } from '@/shared/components/shadcn/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/shared/components/shadcn/tooltip';
+import { MessageSquare } from 'lucide-react';
+
+interface PinCommentTooltipProps {
+  hintOpen: boolean;
+  onOpenComments: (() => void) | undefined;
+  currentPin: PinWithAuthor | null;
+}
+const PinCommentTooltip = ({ hintOpen, onOpenComments, currentPin }: PinCommentTooltipProps) => {
+  return (
+    <TooltipProvider delayDuration={0}>
+      <Tooltip open={hintOpen}>
+        <TooltipTrigger asChild>
+          <Button onClick={onOpenComments} variant="ghost" className="relative">
+            <MessageSquare className="size-5 transition-colors text-black" />
+            {currentPin && (
+              <span className="absolute top-2 right-2 flex h-2 w-2">
+                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-gray-900 opacity-75"></span>
+                <span className="relative inline-flex rounded-full h-2 w-2 bg-gray-900"></span>
+              </span>
+            )}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent className="sm:hidden" side="bottom">
+          <p> 핀댓글 달기</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+};
+
+export default PinCommentTooltip;

--- a/src/features/task-detail/components/TaskDetailTopTab/TaskDetailTopTab.tsx
+++ b/src/features/task-detail/components/TaskDetailTopTab/TaskDetailTopTab.tsx
@@ -59,9 +59,11 @@ const TaskDetailTopTab = ({
             onOpenComments={onOpenComments}
           />
         )}
-        <Button onClick={onToggleReviewAction} variant="ghost">
-          <CheckCircle2 className="size-5" />
-        </Button>
+        {task.requiredReviewerCount > 0 && (
+          <Button onClick={onToggleReviewAction} variant="ghost">
+            <CheckCircle2 className="size-5" />
+          </Button>
+        )}
       </div>
 
       <div className="hidden sm:flex">

--- a/src/features/task-detail/components/TaskDetailTopTab/TaskDetailTopTab.tsx
+++ b/src/features/task-detail/components/TaskDetailTopTab/TaskDetailTopTab.tsx
@@ -36,14 +36,7 @@ const TaskDetailTopTab = ({
   const [hintOpen, setHintOpen] = useState(false);
 
   useEffect(() => {
-    if (!isMobile) return;
-    if (!currentPin) {
-      setHintOpen(false);
-      return;
-    }
-    setHintOpen(true);
-    const t = setTimeout(() => setHintOpen(false), 2000);
-    return () => clearTimeout(t);
+    setHintOpen(isMobile && !!currentPin);
   }, [isMobile, currentPin]);
 
   return (

--- a/src/features/task-detail/components/TaskDetailTopTab/TaskDetailTopTab.tsx
+++ b/src/features/task-detail/components/TaskDetailTopTab/TaskDetailTopTab.tsx
@@ -2,19 +2,14 @@ import { useTaskDetailStore } from '@/features/task-detail/store/useTaskDetailSt
 import { useAiTransformStore } from '@/features/ai-transform/store/useAiTransformStore';
 import BackButton from '@/shared/components/ui/BackButton';
 import { usePdfStore } from '@/features/task-detail/store/usePdfStore';
-import { CheckCircle2, MessageSquare } from 'lucide-react';
+import { CheckCircle2 } from 'lucide-react';
 import TaskReviewActions from '@/features/task-detail/components/TaskDetailTopTab/TaskReviewActions';
 import { Button } from '@/shared/components/shadcn/button';
 import { useShallow } from 'zustand/react/shallow';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/shared/components/shadcn/tooltip';
 import { useIsMobile } from '@/shared/hooks/use-mobile';
 import { useEffect, useState } from 'react';
 import type { TaskDetail } from '@/features/task/types/task.domain.types';
+import PinCommentTooltip from '@/features/task-detail/components/TaskDetailTopTab/PinCommentTooltip';
 
 interface TaskDetailTopTabProps {
   task: TaskDetail;
@@ -27,8 +22,12 @@ const TaskDetailTopTab = ({
   onOpenComments,
   onToggleReviewAction,
 }: TaskDetailTopTabProps) => {
-  const { resetAll, currentPin } = useTaskDetailStore(
-    useShallow((s) => ({ resetAll: s.resetAll, currentPin: s.currentPin })),
+  const { resetAll, currentPin, isCommentDrawerOpen } = useTaskDetailStore(
+    useShallow((s) => ({
+      resetAll: s.resetAll,
+      currentPin: s.currentPin,
+      isCommentDrawerOpen: s.isCommentDrawerOpen,
+    })),
   );
   const resetAiComment = useAiTransformStore((state) => state.reset);
   const resetPdf = usePdfStore((state) => state.resetPdf);
@@ -53,25 +52,13 @@ const TaskDetailTopTab = ({
         {task.title}
       </div>
       <div className="sm:hidden flex gap-2">
-        <TooltipProvider delayDuration={0}>
-          <Tooltip open={hintOpen}>
-            <TooltipTrigger asChild>
-              <Button onClick={onOpenComments} variant="ghost" className="relative">
-                <MessageSquare className="size-5 transition-colors text-black" />
-                {currentPin && (
-                  <span className="absolute top-2 right-2 flex h-2 w-2">
-                    <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-gray-900 opacity-75"></span>
-                    <span className="relative inline-flex rounded-full h-2 w-2 bg-gray-900"></span>
-                  </span>
-                )}
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent className="sm:hidden" side="bottom">
-              <p> 핀댓글 달기</p>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-
+        {!isCommentDrawerOpen && (
+          <PinCommentTooltip
+            currentPin={currentPin}
+            hintOpen={hintOpen}
+            onOpenComments={onOpenComments}
+          />
+        )}
         <Button onClick={onToggleReviewAction} variant="ghost">
           <CheckCircle2 className="size-5" />
         </Button>

--- a/src/features/task-detail/components/TaskReviewActionCollapsible.tsx
+++ b/src/features/task-detail/components/TaskReviewActionCollapsible.tsx
@@ -1,0 +1,33 @@
+import TaskReviewActions from '@/features/task-detail/components/TaskDetailTopTab/TaskReviewActions';
+import type { TaskDetail } from '@/features/task/types/task.domain.types';
+import { Collapsible, CollapsibleContent } from '@/shared/components/shadcn/collapsible';
+import { cn } from '@/shared/lib/utils';
+interface TaskReviewActionCollapsibleProps {
+  isReviewActionOpen: boolean;
+  task: TaskDetail;
+}
+const TaskReviewActionCollapsible = ({
+  isReviewActionOpen,
+  task,
+}: TaskReviewActionCollapsibleProps) => {
+  return (
+    <Collapsible open={isReviewActionOpen}>
+      <CollapsibleContent forceMount>
+        <div
+          className={cn(
+            'sm:hidden grid transition-[grid-template-rows] duration-300 ease-in-out',
+            isReviewActionOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]',
+          )}
+        >
+          <div className="overflow-hidden bg-gray-50">
+            <div className="p-2">
+              <TaskReviewActions task={task} />
+            </div>
+          </div>
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+};
+
+export default TaskReviewActionCollapsible;

--- a/src/pages/AlarmSetupPage.tsx
+++ b/src/pages/AlarmSetupPage.tsx
@@ -28,7 +28,7 @@ const AlarmSetupPage = () => {
           </Button>
         </div>
 
-        <div aria-label="image" className="mt-auto flex shrink-0 flex-col items-center pb-2">
+        <div aria-label="image" className="mt-auto flex shrink-0 flex-col items-center">
           <div aria-label="mockup" className="relative w-[400px] md:w-[640px] flex justify-center">
             <motion.img
               src={AlarmBell}

--- a/src/pages/AvatarSettingsPage.tsx
+++ b/src/pages/AvatarSettingsPage.tsx
@@ -38,16 +38,14 @@ const AvatarSettingsPage = () => {
   };
 
   return (
-    <div className="h-dvh overflow-hidden">
-      <div className="relative mx-auto flex min-h-screen flex-col overflow-hidden">
-        <AvatarHeader />
-        <div className="flex flex-1 flex-col justify-center">
-          <AvatarSelector />
-          <AvatarInfo />
-        </div>
-        <div className="shrink-0 mx-auto pb-6 sm:pb-20">
-          <AvatarSaveBtn handleSave={handleSave} />
-        </div>
+    <div className="h-dvh flex flex-col">
+      <AvatarHeader />
+      <div className="flex flex-1 flex-col justify-center overflow-y-auto">
+        <AvatarSelector />
+        <AvatarInfo />
+      </div>
+      <div className="pb-6 flex mx-auto sm:pb-20">
+        <AvatarSaveBtn handleSave={handleSave} />
       </div>
     </div>
   );

--- a/src/pages/TaskDetailPage.tsx
+++ b/src/pages/TaskDetailPage.tsx
@@ -8,11 +8,9 @@ import FullPageLoader from '@/shared/components/ui/loading/FullPageLoader';
 import { useCommentQuery } from '@/features/comment/hooks/useCommentQuery';
 import TaskDetailInfoSection from '@/features/task-detail/components/TaskDetailInfoSection';
 import TaskDetailCommentSection from '@/features/task-detail/components/TaskDetailCommentSection';
-import TaskReviewActions from '@/features/task-detail/components/TaskDetailTopTab/TaskReviewActions';
-import { cn } from '@/shared/lib/utils';
-import { Collapsible, CollapsibleContent } from '@/shared/components/shadcn/collapsible';
 import CommentDrawerMobile from '@/features/task-detail/components/CommentSection/CommentDrawerMobile';
 import { useShallow } from 'zustand/react/shallow';
+import TaskReviewActionCollapsible from '@/features/task-detail/components/TaskReviewActionCollapsible';
 const TaskDetailPage = () => {
   const { projectId, taskId } = useParams<{ projectId: string; taskId: string }>();
   const { data: comments = [] } = useCommentQuery(projectId!, taskId!);
@@ -44,22 +42,7 @@ const TaskDetailPage = () => {
         onOpenComments={() => setCommentDrawerOpen(true)}
         onToggleReviewAction={() => setIsReviewActionOpen((v) => !v)}
       />
-      <Collapsible open={isReviewActionOpen}>
-        <CollapsibleContent forceMount>
-          <div
-            className={cn(
-              'sm:hidden grid transition-[grid-template-rows] duration-300 ease-in-out',
-              isReviewActionOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]',
-            )}
-          >
-            <div className="overflow-hidden bg-gray-50">
-              <div className="p-2">
-                <TaskReviewActions task={task} />
-              </div>
-            </div>
-          </div>
-        </CollapsibleContent>
-      </Collapsible>
+      <TaskReviewActionCollapsible isReviewActionOpen={isReviewActionOpen} task={task} />
 
       <div className="flex flex-1 overflow-hidden">
         <TaskDetailInfoSection task={task} taskId={taskId} />


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약
- 2026-03-05 QA에서 발견한 개선사항을 반영했습니다.

### ✨ 작업 내용

**1. 아바타 설정 페이지에서 `저장하고 다음` 버튼이 보이지 않는 문제**
- 2차 배포 이후 확인해보니 아바타 설정 페이지에서 위와 같은 문제가 있어 수정했습니다.
- **`overflow-hidden`** 때문에  내용이 화면보다 길어져서 밑으로 밀려난 저장 버튼은 보이지도 않고 스크롤도 안 되는 문제였습니다
    - 만약, 모바일 세로 길이가 너무 짧아서 넘친다면 중앙영역에서만 스크롤이 되도록 했습니다.
    
**2. 현재핀 존재할 때 툴팁 지속**
- 기존에는 currentPin이 있을 때 2초간 툴팁이 떴다가 사라지도록 구현했었는데
- 현재핀이 존재하는 한 툴팁이 계속 보이도록 수정했습니다.

**3. 댓글 드로어가 열려있는 동안 툴팁 뜨지 않도록 수정**
- 핀댓글을 작성하려 댓글 드로어를 열었을 때도 뒤에 툴팁이 계속 떠있는 것이 어색하여
- 댓글 드로어가 열리면 툴팁은 사라지게 했습니다.
<img width="464" height="341" alt="image" src="https://github.com/user-attachments/assets/b494cec7-00c7-4157-ad7f-67d9addc19f7" />


**4. autoZoom 방지를 위해 입력 필드 16px로 수정**
    
    https://devsoyoung.github.io/posts/ios-input-focus-zoom/
    
- auto zoom은 작은 폰트를 키워 사용자를 편하게 만들어주는 기능이기 때문에
- 입력창의 폰트를 굳이 작게 하지 않고 사용하기 편하게  일단 16px로 고정하는 것이 좋아보였습니다.
- 3차 배포 후 모바일에서 직접 사용을 하며 확인을 해보아야 할 것 같습니다.

### 간단한 스타일 수정

**1. 설정 페이지의 이름 변경 취소 버튼 ghost → outline**
<img width="428" height="739" alt="image" src="https://github.com/user-attachments/assets/66820a06-4fd0-4fe2-adff-eda8c1eba85d" />


**2. 다크모드 클래스 삭제**
- 할일 상세 > 첨부파일의 드롭다운 메뉴에서 다크모드 클래스가 설정이 되어있었는데 이 부분 제거했습니다. 
    
**3. QR 설정 페이지 하단 pb-2 여백 제거**
4. 댓글 영역의 폰트 크기 조정
- 모바일에서 확인했을 때 댓글 영역의 폰트가 조금 작은 느낌이 있엇 한단계씩 키워 가독성을 개선했습니다.  

### 컴포넌트 분리

**1. 모바일 할 일 상세 리뷰 액션 Collasible 컴포넌트 분리 
2. 핀댓글 달기 Tooltip 컴포넌트 분리**

### ❗ 참고 사항

- 지금 확인해보니 커밋 제목에 오타가 있네요ㅠㅠ  
클식 삭제 -> 클래스 삭제 입니다. 참고 부탁드립니다!
- 
### #️⃣ 연관 이슈

- Close #451 #452 #453 #454 #455 #456 #457 #466