### PR TITLE
♻️🐛 상태 칸반보드 버그 해결 및 반응형 개선

### DIFF
--- a/src/features/board/components/StatusBoard/StatusBoard.tsx
+++ b/src/features/board/components/StatusBoard/StatusBoard.tsx
@@ -17,10 +17,14 @@ interface StatusBoardProps {
 
 const StatusBoard = ({ projectId }: StatusBoardProps) => {
   const columnsData = useStatusBoardQueries(projectId);
-  const { sensors, activeTask, onDragStart, onDragOver, onDragEnd } = useTaskDrag({ projectId });
 
   const { isMobileView, chunkedColumns, currentIndex, scrollContainerRef, onScroll } =
     useBoardSlider(columnsData);
+
+  const { sensors, activeTask, onDragStart, onDragOver, onDragEnd } = useTaskDrag({
+    projectId,
+    isMobileView,
+  });
 
   const handleIndicatorClick = (index: number) => {
     const el = scrollContainerRef.current;

--- a/src/features/board/components/StatusBoard/StatusBoard.tsx
+++ b/src/features/board/components/StatusBoard/StatusBoard.tsx
@@ -1,195 +1,78 @@
-import {
-  DndContext,
-  DragOverlay,
-  useSensor,
-  useSensors,
-  PointerSensor,
-  TouchSensor,
-  type DragStartEvent,
-  type DragOverEvent,
-  defaultDropAnimationSideEffects,
-} from '@dnd-kit/core';
-import { useRef, useState, useEffect } from 'react';
+import { DndContext, DragOverlay, defaultDropAnimationSideEffects } from '@dnd-kit/core';
 import { createPortal } from 'react-dom';
-import { useQueryClient } from '@tanstack/react-query';
-import { useIsMobile } from '@/shared/hooks/use-mobile';
+import { cn } from '@/shared/lib/utils';
 import TaskCard from '@/features/task/components/TaskCard/TaskCard';
 import StatusColumn from '@/features/board/components/StatusBoard/StatusColumn';
-import {
-  useMoveTaskMutation,
-  optimisticallyMoveTask,
-  type MoveTaskParams,
-} from '@/features/task/hooks/mutation/useMoveTaskMutation';
 import { TASK_STATUS_META } from '@/features/task/constants/task.domain.constants';
-import type { TaskListItem, TaskStatus } from '@/features/task/types/task.domain.types';
-import { useStatusBoardQueries } from '@/features/board/hooks/useStatusBoardQueries';
-import { useSortStore } from '@/features/board/store/useSortStore';
 import { ColumnFallback } from '@/features/board/components/StatusBoard/ColumnFallback';
+import { useStatusBoardQueries } from '@/features/board/hooks/useStatusBoardQueries';
+import type { TaskStatus } from '@/features/task/types/task.domain.types';
+import type { TaskQuery } from '@/features/task/types/task.query.types';
+import { useTaskDrag } from '@/features/board/hooks/useTaskDrag';
+import { useBoardSlider } from '@/features/board/hooks/useBoardSlider';
 
 interface StatusBoardProps {
   projectId?: string;
 }
 
 const StatusBoard = ({ projectId }: StatusBoardProps) => {
-  const queryClient = useQueryClient();
-  const [activeTask, setActiveTask] = useState<TaskListItem | null>(null);
-
-  const isMobile = useIsMobile();
-
-  const sensors = useSensors(
-    useSensor(isMobile ? TouchSensor : PointerSensor, {
-      activationConstraint: isMobile ? { delay: 250, tolerance: 5 } : { distance: 10 },
-    }),
-  );
-
-  const moveTaskMutation = useMoveTaskMutation();
   const columnsData = useStatusBoardQueries(projectId);
+  const { sensors, activeTask, onDragStart, onDragOver, onDragEnd } = useTaskDrag({ projectId });
 
-  const { sortBy, direction } = useSortStore();
-  const sortStateRef = useRef({ sortBy, direction });
+  const { isMobileView, chunkedColumns, currentIndex, scrollContainerRef, onScroll } =
+    useBoardSlider(columnsData);
 
-  useEffect(() => {
-    sortStateRef.current = { sortBy, direction };
-  }, [sortBy, direction]);
-
-  const dropTargetRef = useRef<{ activeId: string; toStatus: TaskStatus; overId?: string } | null>(
-    null,
+  const renderFallback = (status: TaskStatus, state: 'loading' | 'error') => (
+    <ColumnFallback key={status} status={status} state={state} />
   );
 
-  const [currentIndex, setCurrentIndex] = useState(0);
-  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+  const renderColumn = (status: TaskStatus, query: TaskQuery) => {
+    if (query.isLoading) return renderFallback(status, 'loading');
+    if (query.isError || !query.data) return renderFallback(status, 'error');
 
-  const onScroll = () => {
-    const el = scrollContainerRef.current;
-    if (!el) return;
-    setCurrentIndex(Math.round(el.scrollLeft / el.clientWidth));
-  };
+    const column = TASK_STATUS_META.find((c) => c.status === status)!;
 
-  const onDragStart = (event: DragStartEvent) => {
-    const activeData = event.active.data.current;
-    if (activeData?.type === 'Task') {
-      const task = activeData.task as TaskListItem;
-      setActiveTask(task);
-      dropTargetRef.current = {
-        activeId: task.taskId,
-        toStatus: task.status,
-      };
-    }
-  };
-
-  const onDragEnd = () => {
-    if (activeTask && dropTargetRef.current) {
-      const { toStatus, overId } = dropTargetRef.current;
-
-      const isStatusChanged = activeTask.status !== toStatus;
-      const isOrderChanged = !!overId;
-
-      if (isStatusChanged || isOrderChanged) {
-        const { sortBy: currentSortBy, direction: currentDirection } = sortStateRef.current;
-
-        const params: MoveTaskParams = {
-          projectId: activeTask.projectId,
-          activeTaskId: activeTask.taskId,
-          fromStatus: activeTask.status,
-          toStatus,
-          overId,
-          queryIdentifier: projectId || 'me',
-          sortBy: currentSortBy,
-          direction: currentDirection,
-          activeTask: activeTask,
-        };
-
-        moveTaskMutation.mutate(params);
-      }
-    }
-
-    setActiveTask(null);
-    dropTargetRef.current = null;
-  };
-
-  const onDragOver = ({ active, over }: DragOverEvent) => {
-    if (!over) return;
-
-    const { sortBy: currentSortBy, direction: currentDirection } = sortStateRef.current;
-
-    const activeTask = active.data.current?.task as TaskListItem | undefined;
-    const overData = over.data.current;
-    const activeId = active.id as string;
-
-    if (!activeTask || activeId === over.id) return;
-
-    const toStatus =
-      overData?.type === 'Task'
-        ? overData.task.status
-        : overData?.type === 'Column'
-          ? overData.column.status
-          : undefined;
-    if (!toStatus) return;
-
-    const overId = overData?.type === 'Task' ? (over.id as string) : undefined;
-
-    if (
-      dropTargetRef.current?.activeId === activeId &&
-      dropTargetRef.current?.toStatus === toStatus &&
-      dropTargetRef.current?.overId === overId
-    ) {
-      return;
-    }
-
-    dropTargetRef.current = { activeId, toStatus, overId };
-
-    const params: MoveTaskParams = {
-      projectId: activeTask.projectId,
-      activeTaskId: activeId,
-      fromStatus: activeTask.status,
-      toStatus,
-      overId,
-      queryIdentifier: projectId || 'me',
-      sortBy: currentSortBy,
-      direction: currentDirection,
-      activeTask: activeTask,
-    };
-
-    optimisticallyMoveTask(queryClient, params);
+    return <StatusColumn key={status} column={column} query={query} projectId={projectId} />;
   };
 
   return (
-    <div className="flex-1 flex flex-col p-3 overflow-hidden h-full">
+    <div className="flex-1 flex flex-col p-3 h-full">
       <DndContext
         sensors={sensors}
         onDragStart={onDragStart}
-        onDragEnd={onDragEnd}
         onDragOver={onDragOver}
+        onDragEnd={onDragEnd}
       >
-        <div className="flex justify-center gap-2 pb-2 pt-0.5 shrink-0 md:hidden">
-          {TASK_STATUS_META.map((_, idx) => (
-            <div
-              key={idx}
-              className="h-2 rounded-full bg-gray-400 transition-[width, background-color] duration-300 ease-out"
-              style={{
-                width: idx === currentIndex ? 24 : 8,
-                opacity: idx === currentIndex ? 1 : 0.5,
-              }}
-            />
-          ))}
-        </div>
+        {isMobileView && (
+          <div className="flex justify-center gap-2 pb-2 pt-0.5 shrink-0 xl:hidden">
+            {chunkedColumns.map((_, idx) => (
+              <div
+                key={idx}
+                className="h-2 rounded-full bg-gray-400 transition-[width, background-color] duration-300 ease-out"
+                style={{
+                  width: idx === currentIndex ? 24 : 8,
+                  opacity: idx === currentIndex ? 1 : 0.5,
+                }}
+              />
+            ))}
+          </div>
+        )}
 
         <div
           ref={scrollContainerRef}
           onScroll={onScroll}
-          className="flex flex-nowrap flex-grow gap-3 overflow-x-auto overflow-y-hidden items-stretch scroll-smooth snap-x snap-mandatory md:snap-none"
+          className={cn(
+            'flex flex-grow gap-3 items-stretch scroll-smooth',
+            isMobileView ? 'overflow-x-auto snap-x snap-mandatory' : 'overflow-hidden',
+          )}
         >
-          {columnsData.map(({ status, query }) => {
-            if (query.isLoading)
-              return <ColumnFallback key={status} status={status} state="loading" />;
-            if (query.isError || !query.data)
-              return <ColumnFallback key={status} status={status} state="error" />;
-
-            const column = TASK_STATUS_META.find((c) => c.status === status)!;
-            return (
-              <StatusColumn key={status} column={column} query={query} projectId={projectId} />
-            );
-          })}
+          {isMobileView
+            ? chunkedColumns.map((group, pageIdx) => (
+                <div key={pageIdx} className="flex w-full flex-shrink-0 gap-3 snap-center">
+                  {group.map(({ status, query }) => renderColumn(status, query))}
+                </div>
+              ))
+            : columnsData.map(({ status, query }) => renderColumn(status, query))}
         </div>
 
         {createPortal(

--- a/src/features/board/components/StatusBoard/StatusBoard.tsx
+++ b/src/features/board/components/StatusBoard/StatusBoard.tsx
@@ -22,6 +22,16 @@ const StatusBoard = ({ projectId }: StatusBoardProps) => {
   const { isMobileView, chunkedColumns, currentIndex, scrollContainerRef, onScroll } =
     useBoardSlider(columnsData);
 
+  const handleIndicatorClick = (index: number) => {
+    const el = scrollContainerRef.current;
+    if (!el) return;
+
+    el.scrollTo({
+      left: el.clientWidth * index,
+      behavior: 'smooth',
+    });
+  };
+
   const renderFallback = (status: TaskStatus, state: 'loading' | 'error') => (
     <ColumnFallback key={status} status={status} state={state} />
   );
@@ -48,6 +58,7 @@ const StatusBoard = ({ projectId }: StatusBoardProps) => {
             {chunkedColumns.map((_, idx) => (
               <div
                 key={idx}
+                onClick={() => handleIndicatorClick(idx)}
                 className="h-2 rounded-full bg-gray-400 transition-[width, background-color] duration-300 ease-out"
                 style={{
                   width: idx === currentIndex ? 24 : 8,

--- a/src/features/board/components/StatusBoard/StatusColumn.tsx
+++ b/src/features/board/components/StatusBoard/StatusColumn.tsx
@@ -1,6 +1,5 @@
 import { SortableContext } from '@dnd-kit/sortable';
 import { useDroppable } from '@dnd-kit/core';
-import { useRef } from 'react';
 import TaskCard from '@/features/task/components/TaskCard/TaskCard';
 import type { TaskStatusMeta } from '@/features/task/types/task.domain.types';
 import type { TaskQuery } from '@/features/task/types/task.query.types';
@@ -8,6 +7,7 @@ import { getTaskCountByStatus } from '@/features/task/utils/taskUtils';
 import { useStatusTaskCountQueries } from '@/features/board/hooks/useStatusTaskCountQueries';
 import { useTagFilterStore } from '@/features/tag/store/useTagFilterStore';
 import InlineLoader from '@/shared/components/ui/loading/InlineLoader';
+import { useInfiniteScroll } from '@/features/board/hooks/useInfiniteScroll';
 
 interface StatusColumnProps {
   column: TaskStatusMeta;
@@ -19,6 +19,7 @@ const StatusColumn = ({ column, query, projectId }: StatusColumnProps) => {
   const { data: statusTaskCountList } = useStatusTaskCountQueries(projectId);
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = query;
   const { selectedTags } = useTagFilterStore();
+
   const tasks = data?.pages.flatMap((page) => page.tasks) || [];
   const sortedTasks = Array.from(new Map(tasks.map((t) => [t.taskId, t])).values());
 
@@ -36,24 +37,16 @@ const StatusColumn = ({ column, query, projectId }: StatusColumnProps) => {
     data: { type: 'Column', column },
   });
 
-  const observer = useRef<IntersectionObserver | null>(null);
-  const lastTaskRef = (node: HTMLDivElement) => {
-    if (isFetchingNextPage) return;
-    if (observer.current) observer.current.disconnect();
-
-    observer.current = new IntersectionObserver((entries) => {
-      if (entries[0].isIntersecting && hasNextPage) {
-        fetchNextPage();
-      }
-    });
-
-    if (node) observer.current.observe(node);
-  };
+  const lastTaskRef = useInfiniteScroll({
+    isFetching: isFetchingNextPage,
+    hasNextPage,
+    onLoadMore: fetchNextPage,
+  });
 
   return (
     <div
       ref={setNodeRef}
-      className="bg-gray-200 m-0.5 md:m-1 shadow-md rounded-xl flex flex-col flex-none w-[calc(100vw-32px)] snap-center md:w-full min-w-[250px] md:snap-align-none md:flex-1"
+      className="bg-gray-200 m-0.5 md:m-1 shadow-md rounded-xl flex flex-col flex-1 min-w-[250px]"
     >
       <div className="bg-gray-200 shadow-xs text-md h-[45px] rounded-md p-3 label1-regular flex items-center">
         <div className="flex gap-2 text-gray-600 items-center">

--- a/src/features/board/hooks/useBoardSlider.ts
+++ b/src/features/board/hooks/useBoardSlider.ts
@@ -1,0 +1,49 @@
+import { useEffect, useRef, useState } from 'react';
+import { useResponsiveColumns } from '@/features/board/hooks/useResponsiveColumns';
+import type { ColumnData } from '@/features/board/types/board.domain.types';
+
+export const useBoardSlider = (columnsData: ColumnData[]) => {
+  const visibleCount = useResponsiveColumns();
+  const isMobileView = visibleCount < 4;
+
+  const getChunkedColumns = () => {
+    if (!isMobileView) return [];
+
+    const result = [];
+    for (let i = 0; i < columnsData.length; i += visibleCount) {
+      result.push(columnsData.slice(i, i + visibleCount));
+    }
+    return result;
+  };
+
+  const chunkedColumns = getChunkedColumns();
+
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    setCurrentIndex(0);
+  }, [visibleCount]);
+
+  const calculatePageIndex = (scrollLeft: number, pageWidth: number) =>
+    Math.round(scrollLeft / pageWidth);
+
+  const onScroll = () => {
+    if (!isMobileView) return;
+
+    const el = scrollContainerRef.current;
+    if (!el) return;
+
+    const nextIndex = calculatePageIndex(el.scrollLeft, el.clientWidth);
+    setCurrentIndex(nextIndex);
+  };
+
+  return {
+    visibleCount,
+    isMobileView,
+    chunkedColumns,
+    currentIndex,
+    scrollContainerRef,
+    onScroll,
+  };
+};

--- a/src/features/board/hooks/useInfiniteScroll.ts
+++ b/src/features/board/hooks/useInfiniteScroll.ts
@@ -1,0 +1,26 @@
+import { useRef } from 'react';
+
+interface infiniteScrollProps {
+  isFetching: boolean;
+  hasNextPage?: boolean;
+  onLoadMore: () => void;
+}
+
+export const useInfiniteScroll = ({ isFetching, hasNextPage, onLoadMore }: infiniteScrollProps) => {
+  const observer = useRef<IntersectionObserver | null>(null);
+
+  const lastItemRef = (node: HTMLDivElement) => {
+    if (isFetching) return;
+    if (observer.current) observer.current.disconnect();
+
+    observer.current = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting && hasNextPage) {
+        onLoadMore();
+      }
+    });
+
+    if (node) observer.current.observe(node);
+  };
+
+  return lastItemRef;
+};

--- a/src/features/board/hooks/useResponsiveColumns.ts
+++ b/src/features/board/hooks/useResponsiveColumns.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react';
+
+export function useResponsiveColumns() {
+  const [visibleCount, setVisibleCount] = useState(1);
+
+  useEffect(() => {
+    const update = () => {
+      const width = window.innerWidth;
+
+      if (width > 1024) setVisibleCount(4);
+      else if (width >= 640) setVisibleCount(2);
+      else setVisibleCount(1);
+    };
+
+    update();
+
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  }, []);
+
+  return visibleCount;
+}

--- a/src/features/board/hooks/useTaskDrag.ts
+++ b/src/features/board/hooks/useTaskDrag.ts
@@ -1,0 +1,144 @@
+import {
+  useSensor,
+  useSensors,
+  PointerSensor,
+  TouchSensor,
+  type DragStartEvent,
+  type DragOverEvent,
+} from '@dnd-kit/core';
+import { useRef, useState, useEffect } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useIsMobile } from '@/shared/hooks/use-mobile';
+import {
+  useMoveTaskMutation,
+  optimisticallyMoveTask,
+  type MoveTaskParams,
+} from '@/features/task/hooks/mutation/useMoveTaskMutation';
+import { useSortStore } from '@/features/board/store/useSortStore';
+import type { TaskListItem, TaskStatus } from '@/features/task/types/task.domain.types';
+
+interface TaskDragProps {
+  projectId?: string;
+}
+
+export const useTaskDrag = ({ projectId }: TaskDragProps) => {
+  const queryClient = useQueryClient();
+  const [activeTask, setActiveTask] = useState<TaskListItem | null>(null);
+
+  const isMobile = useIsMobile();
+
+  const sensors = useSensors(
+    useSensor(isMobile ? TouchSensor : PointerSensor, {
+      activationConstraint: isMobile ? { delay: 250, tolerance: 5 } : { distance: 10 },
+    }),
+  );
+
+  const moveTaskMutation = useMoveTaskMutation();
+
+  const { sortBy, direction } = useSortStore();
+  const sortStateRef = useRef({ sortBy, direction });
+
+  useEffect(() => {
+    sortStateRef.current = { sortBy, direction };
+  }, [sortBy, direction]);
+
+  const dropTargetRef = useRef<{ activeId: string; toStatus: TaskStatus; overId?: string } | null>(
+    null,
+  );
+
+  const onDragStart = (event: DragStartEvent) => {
+    const activeData = event.active.data.current;
+    if (activeData?.type === 'Task') {
+      const task = activeData.task as TaskListItem;
+      setActiveTask(task);
+      dropTargetRef.current = {
+        activeId: task.taskId,
+        toStatus: task.status,
+      };
+    }
+  };
+
+  const onDragEnd = () => {
+    if (activeTask && dropTargetRef.current) {
+      const { toStatus, overId } = dropTargetRef.current;
+
+      const isStatusChanged = activeTask.status !== toStatus;
+      const isOrderChanged = !!overId;
+
+      if (isStatusChanged || isOrderChanged) {
+        const { sortBy: currentSortBy, direction: currentDirection } = sortStateRef.current;
+
+        const params: MoveTaskParams = {
+          projectId: activeTask.projectId,
+          activeTaskId: activeTask.taskId,
+          fromStatus: activeTask.status,
+          toStatus,
+          overId,
+          queryIdentifier: projectId || 'me',
+          sortBy: currentSortBy,
+          direction: currentDirection,
+          activeTask: activeTask,
+        };
+
+        moveTaskMutation.mutate(params);
+      }
+    }
+
+    setActiveTask(null);
+    dropTargetRef.current = null;
+  };
+
+  const onDragOver = ({ active, over }: DragOverEvent) => {
+    if (!over) return;
+
+    const { sortBy: currentSortBy, direction: currentDirection } = sortStateRef.current;
+
+    const activeTask = active.data.current?.task as TaskListItem | undefined;
+    const overData = over.data.current;
+    const activeId = active.id as string;
+
+    if (!activeTask || activeId === over.id) return;
+
+    const toStatus =
+      overData?.type === 'Task'
+        ? overData.task.status
+        : overData?.type === 'Column'
+          ? overData.column.status
+          : undefined;
+    if (!toStatus) return;
+
+    const overId = overData?.type === 'Task' ? (over.id as string) : undefined;
+
+    if (
+      dropTargetRef.current?.activeId === activeId &&
+      dropTargetRef.current?.toStatus === toStatus &&
+      dropTargetRef.current?.overId === overId
+    ) {
+      return;
+    }
+
+    dropTargetRef.current = { activeId, toStatus, overId };
+
+    const params: MoveTaskParams = {
+      projectId: activeTask.projectId,
+      activeTaskId: activeId,
+      fromStatus: activeTask.status,
+      toStatus,
+      overId,
+      queryIdentifier: projectId || 'me',
+      sortBy: currentSortBy,
+      direction: currentDirection,
+      activeTask: activeTask,
+    };
+
+    optimisticallyMoveTask(queryClient, params);
+  };
+
+  return {
+    sensors,
+    activeTask,
+    onDragStart,
+    onDragOver,
+    onDragEnd,
+  };
+};

--- a/src/features/board/hooks/useTaskDrag.ts
+++ b/src/features/board/hooks/useTaskDrag.ts
@@ -8,7 +8,6 @@ import {
 } from '@dnd-kit/core';
 import { useRef, useState, useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
-import { useIsMobile } from '@/shared/hooks/use-mobile';
 import {
   useMoveTaskMutation,
   optimisticallyMoveTask,
@@ -19,17 +18,16 @@ import type { TaskListItem, TaskStatus } from '@/features/task/types/task.domain
 
 interface TaskDragProps {
   projectId?: string;
+  isMobileView: boolean;
 }
 
-export const useTaskDrag = ({ projectId }: TaskDragProps) => {
+export const useTaskDrag = ({ projectId, isMobileView }: TaskDragProps) => {
   const queryClient = useQueryClient();
   const [activeTask, setActiveTask] = useState<TaskListItem | null>(null);
 
-  const isMobile = useIsMobile();
-
   const sensors = useSensors(
-    useSensor(isMobile ? TouchSensor : PointerSensor, {
-      activationConstraint: isMobile ? { delay: 250, tolerance: 5 } : { distance: 10 },
+    useSensor(isMobileView ? TouchSensor : PointerSensor, {
+      activationConstraint: isMobileView ? { delay: 250, tolerance: 5 } : { distance: 10 },
     }),
   );
 


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약

- 상태 칸반보드에서 발생하는 버그를 해결했습니다.
- 상태 칸반보드의 반응형을 개선했습니다.

<br/><br/>

### ✨ 작업 내용

#### 1. 상태 칸반보드 반응형 개선 (`useResponsiveColumn`, `useBoardSlider`)
- 기존에는 컬럼 하나씩 가로 스크롤을 발생시키는 구조였습니다.
- 이를 `chunkedColumns`를 사용하여 컬럼을 `페이지 단위`로 묶어 슬라이드 방식 구조를 개선했습니다.
- 여기서 페이지 단위라는 것은 하나의 페이지 = 한 화면 입니다.
- 기존에는 flex-none + width 고정 레이아웃 구조를 사용했었습니다.
- 페이지 단위로 레이아웃이 제어되어야 하므로 flex-1 + min-width 구조로 변경했습니다.
- 의견주셨던 대로 아래와 같은 형식으로 페이지 단위를 나누었습니다.
   - **모바일**: [ [todo], [progress], [review], [done] ] **그 이하** → 1개
   - **태블릿**: [ [todo, progress], [review, done] ] **640px 이상** → 2개
   - **데스크탑**: [ [todo, progress, review, done] ] **1024px 초과** → 4개

<br/>

#### 2. 상태 보드 렌더링 시 깜빡임 문제 해결
 - 1번 방식으로 개선함에 따라, 보드 너비 변동으로 인해 보드 깜빡거림 문제가 해결되었습니다.

>  또한, 드래그 앤 드랍이 안 되던 문제도 혹시 컬럼을 하나씩 + 컬럼 너비를 직접 calc 하던 구조 때문에 안되었을 수도 있어 이 부분은 테스트가 필요합니다.

<br/>

#### 3. 모바일 판단 기준 변경
- 모바일 판단 기준을 shadcn에서 제공하는 `use-Mobile (isMobile)`에서 커스텀 훅 `useBoardSlider (isMobileView => visibleCount <4)` 기반으로 수정했습니다.
- 기존 use-mobile은 브레이크 포인트가 648이라 제가 의도하고자 한 바가 제대로 적용되지 않습니다. (태블릿일 때 드래그 앤 드랍이 안 되는 문제 발생 가능성 존재) 
- 그렇기 때문에 제가 구현한 모바일 판단 기준인 `visibleCount < 4`를 모바일 판단 기준으로 사용해주었습니다.

<br/>

#### 4. 스크롤 인덱스 계산 로직 개선
- 기존에는 scrollLeft / clientWidth 를 통해 컴포넌트 내부에서 직접적인 계산이 이루어졌었습니다.
- 이는 화면 크기가 변경되었을 때 기존 index가 유지되며, 잘못된 페이지를 가리킬 수 있습니다.
- 이를 `calculatePageIndex`로 분리하여, 계산 로직을 명확화 및 재사용할 수 있도록 했습니다.
- 추가적으로 useEffect를 사용하여 visibleCount가 변경되었을 때, index가 초기화되도록 했습니다.

<br/>

#### 5. 코드 가독성을 위한 훅 분리 `useInfiniteScroll`, `useTaskDrag`
- 코드 가독성을 위해서 드래그 로직과 무한 스크롤 로직을 훅으로 분리했습니다.
- 크게 변경되는 로직 없이, 분리만 진행했습니다. 

<br/>

#### 6. Status Board, Status Column 에 분리한 훅, 새롭게 구현한 훅 적용
- 분리한 훅들을 적용 완료했습니다.
- 새롭게 구현한 훅들을 적용 완료했습니다.
- 최종적으로 상태보드에 태블릿 반응형 추가, 렌더링 깜빡거림 해결, 드래그앤드랍 버그 수정 시도 완료했습니다.

<br/>

#### 7. 인디케이터에 터치 시 페이지 이동 추가
- UX 개선을 위해 인디케이터 클릭시 해당 페이지로 전환되는 기능을 추가했습니다.

<br/>

#### 8. 추가적으로 코드 리팩터링
- JSX 내부에서 분기하던 로직을 `renderColumn`, `renderFallback`으로 분리하여 JSX 가독성을 개선하고 중복적인 코드를 제거했습니다.

<br/>

#### 📷 이미지 첨부

| 모바일-1 | 모바일-2 |
|---|---|
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/59d7b70b-fd62-464d-8068-98bf960de4d0" />  | <img width="400" alt="image" src="https://github.com/user-attachments/assets/1c87576f-e23e-42ec-a16c-c5556433e829" /> |

|  태블릿-1 | 태블릿-2 |
|---|---|
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/5786e332-88f2-48e7-9607-37eda1dab6e3" /> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/70bbd656-3be8-4a38-9cd9-b013840565f6" /> |

| 데스크탑-1 | 데스크탑-2 |
|---|---|
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/20300e9f-30d1-42e5-bd08-abd413c48546" /> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/19dc4cb2-67c9-485c-83a2-edc19ef37404" /> |

<br/>

#### 📽️ 영상 첨부

##### 인디케이터 클릭

https://github.com/user-attachments/assets/d4c0d6cf-85be-4341-8e0d-46e24d2523c1

<br/>

##### 태블릿 

https://github.com/user-attachments/assets/7e48bf42-45bd-4b92-a9d5-2cde42646a1d

<br/>

##### 모바일

https://github.com/user-attachments/assets/e8282667-2e78-4bdd-a775-1729923a0694

<br/>

##### 데스크탑

https://github.com/user-attachments/assets/d6047e2a-b345-4f4b-ad1b-623a47200715



<br/><br/>

### ❗ 참고 사항

- 멤버 보드는 드래그 앤 드랍 로직이 존재하지 않으며, 컬럼 수가 고정되어있지 않다는 점이 있어 별도로 작업하려고 합니다.
- 제목이 길어질 듯 하여 title에 이슈 번호는 기재하지 않았습니다. 아래 연관 이슈를 확인해주세요!

<br/><br/>

### #️⃣ 연관 이슈

- Close #439, #440, #461
