### PR TITLE
🔧 (#474) 로컬 API 프록시를 QA 환경과 동일한 엔드포인트로 변경

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -45,7 +45,7 @@ export default defineConfig(({ mode }) => {
     server: {
       proxy: {
         '/api': {
-          target: 'https://api.boost.ai.kr',
+          target: 'https://qa.boost.ai.kr',
           changeOrigin: true,
           secure: false,
           // rewrite: (path) => path.replace(/^\/api/, ''),


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약

- 로컬 개발 환경에서 API 프록시 대상 서버를 QA 환경과 동일하게 변경했습니다.

<br/>

### ✨ 작업 내용

- 기존 https://api.boost.ai.kr → 'https://qa.boost.ai.kr'
- QA 기준으로 API 동작 테스트 가능하도록 환경을 통일했습니다.
- 실제 운영 서버에 불필요한 요청 방지하고 QA 단계에서 발생하는 이슈를 로컬에서도 재현 가능하도록 했습니다.

<br/>

### ❗ 참고 사항

- 해당 PR(chore/...)은 이전 PR이 머지되지 않은 상태에서 생성되어, GitHub CI/CD 워크플로우가 정상적으로 동작하지 않을 수 있습니다.
- 로컬에서 QA 서버로 API 호출 정상 동작 확인 완료했습니다.

<br/>

### #️⃣ 연관 이슈

- Close #474 
