### PR TITLE
♻️ (#390) Memo Modal 내부 navigate 전달 구조 수정

### DIFF
--- a/src/features/memo/components/MemoEditor/MemoEditor.tsx
+++ b/src/features/memo/components/MemoEditor/MemoEditor.tsx
@@ -77,7 +77,7 @@ const MemoEditor = () => {
       navigate(ROUTES.PROJECT_MEMO_DETAIL(projectId ?? '', memoId ?? ''));
       return;
     }
-    showUnsavedChangesModal(projectId ?? '', navigate);
+    showUnsavedChangesModal(projectId ?? '');
   };
 
   if (!projectId) return <div className="p-4">프로젝트 ID를 찾을 수 없습니다.</div>;

--- a/src/features/memo/components/MemoList/MemoList.tsx
+++ b/src/features/memo/components/MemoList/MemoList.tsx
@@ -1,5 +1,4 @@
 import { useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
 import FullPageLoader from '@/shared/components/ui/loading/FullPageLoader';
 import MemoListHeader from '@/features/memo/components/MemoList/MemoListHeader';
 import MemoTable from '@/features/memo/components/MemoList/MemoTable';
@@ -18,7 +17,6 @@ const MemoList = ({ projectId, onSelectMemo }: MemoListProps) => {
   const { data: memos, isLoading } = useMemosQuery(projectId);
   const tableContainerRef = useRef<HTMLDivElement>(null);
 
-  const navigate = useNavigate();
   const { showDeleteMemoModal } = useMemoModals();
 
   const { selectedRows, toggleSelectAll, toggleSelectRow, removeSelected } = useRowSelection();
@@ -30,7 +28,7 @@ const MemoList = ({ projectId, onSelectMemo }: MemoListProps) => {
   });
 
   const handleDelete = (ids: string[]) => {
-    showDeleteMemoModal(ids, navigate, (deletedIds) => {
+    showDeleteMemoModal(ids, (deletedIds) => {
       removeSelected(deletedIds);
     });
   };

--- a/src/features/memo/components/MemoModal/MemoDeleteModalContent.tsx
+++ b/src/features/memo/components/MemoModal/MemoDeleteModalContent.tsx
@@ -1,5 +1,5 @@
 import toast from 'react-hot-toast';
-import type { NavigateFunction } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { ROUTES } from '@/app/routes/routeHelpers';
 import { Button } from '@/shared/components/shadcn/button';
 import MovingBoo from '@/shared/components/ui/MovingBoo';
@@ -10,18 +10,14 @@ import { useProjectStore } from '@/features/project/store/useProjectStore';
 
 interface MemoDeleteModalContentProps {
   memoIds: string[];
-  navigate: NavigateFunction;
   onDeleteSuccess?: (deletedIds: string[]) => void;
 }
 
-const MemoDeleteModalContent = ({
-  memoIds,
-  navigate,
-  onDeleteSuccess,
-}: MemoDeleteModalContentProps) => {
+const MemoDeleteModalContent = ({ memoIds, onDeleteSuccess }: MemoDeleteModalContentProps) => {
   const { projectData } = useProjectStore();
   const { resetModal } = useModal();
   const { mutateAsync: deleteMemo, isPending } = useDeleteMemoMutation(projectData.id);
+  const navigate = useNavigate();
 
   if (!projectData) return null;
 

--- a/src/features/memo/components/MemoModal/MemoUnsavedModalContent.tsx
+++ b/src/features/memo/components/MemoModal/MemoUnsavedModalContent.tsx
@@ -1,4 +1,4 @@
-import type { NavigateFunction } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { ROUTES } from '@/app/routes/routeHelpers';
 import { Button } from '@/shared/components/shadcn/button';
 import { useModal } from '@/shared/hooks/useModal';
@@ -6,11 +6,11 @@ import MovingBoo from '@/shared/components/ui/MovingBoo';
 
 interface MemoUnsavedModalContentProps {
   projectId: string;
-  navigate: NavigateFunction;
 }
 
-const MemoUnsavedModalContent = ({ projectId, navigate }: MemoUnsavedModalContentProps) => {
+const MemoUnsavedModalContent = ({ projectId }: MemoUnsavedModalContentProps) => {
   const { resetModal } = useModal();
+  const navigate = useNavigate();
 
   const handleConfirm = () => {
     resetModal();

--- a/src/features/memo/hooks/modal/useMemoModals.tsx
+++ b/src/features/memo/hooks/modal/useMemoModals.tsx
@@ -1,4 +1,3 @@
-import type { NavigateFunction } from 'react-router-dom';
 import MemoDeleteModalContent from '@/features/memo/components/MemoModal/MemoDeleteModalContent';
 import MemoUnsavedModalContent from '@/features/memo/components/MemoModal/MemoUnsavedModalContent';
 import MemoEmptyFieldsModalContent from '@/features/memo/components/MemoModal/MemoEmptyFieldsModalContent';
@@ -11,7 +10,6 @@ export const useMemoModals = () => {
 
   const showDeleteMemoModal = (
     memoIds: string[],
-    navigate: NavigateFunction,
     onDeleteSuccess?: (deletedIds: string[]) => void,
   ) => {
     if (!projectData) return;
@@ -24,23 +22,17 @@ export const useMemoModals = () => {
           ? `${memoIds.length}개의 메모를 삭제하시겠어요? 🥹`
           : '정말로 이 메모를 삭제하시나요? 🥹',
       size: 'sm',
-      content: (
-        <MemoDeleteModalContent
-          memoIds={memoIds}
-          navigate={navigate}
-          onDeleteSuccess={onDeleteSuccess}
-        />
-      ),
+      content: <MemoDeleteModalContent memoIds={memoIds} onDeleteSuccess={onDeleteSuccess} />,
     });
   };
 
-  const showUnsavedChangesModal = (projectId: string, navigate: NavigateFunction) => {
+  const showUnsavedChangesModal = (projectId: string) => {
     showCustom({
       title: '변경 사항 확인',
       titleAlign: 'center',
       description: '저장되지 않은 변경 사항이 있습니다.',
       size: 'sm',
-      content: <MemoUnsavedModalContent projectId={projectId} navigate={navigate} />,
+      content: <MemoUnsavedModalContent projectId={projectId} />,
     });
   };
 

--- a/src/features/project/components/ProjectPageComponents/ProjectHeader.tsx
+++ b/src/features/project/components/ProjectPageComponents/ProjectHeader.tsx
@@ -27,7 +27,7 @@ const ProjectHeader = ({ project }: ProjectHeaderProps) => {
   const handleButtonClick = () => {
     if (location.pathname.includes('/memo')) {
       if (isDirty) {
-        showUnsavedChangesModal(project.id, navigate);
+        showUnsavedChangesModal(project.id);
         return;
       }
       navigate(ROUTES.PROJECT_MEMO_EDIT(project.id));


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약

- Memo Modal 과 관련하여 props로 내려주던 navigate 구조를 개선했습니다.

<br/>

### ✨ 작업 내용

- #389 가 해결됨에 따라 진행된 부분입니다.
- 해당 버그가 수정된 PR은 #392 입니다. 자세한 내용은 이슈와 PR 확인 부탁드립니다.
- 모달 내부에서 router hook을 사용할 수 있게 되었으므로, props로 내려줄 필요가 없어 모달에서 직접 라우터 훅을 사용할 수 있도록 수정했습니다.
- 메모 삭제할 때 뜨는 모달, 저장되지 않은 메모일 때 뜨는 모달에 적용 완료했습니다.
- 해당 모달을 사용하던 메모 에디터, 메모 목록, 프로젝트 헤더에 적용 완료했습니다.

<br/>

### ❗ 참고 사항

- X

<br/>

### #️⃣ 연관 이슈

- Close #390 
