### PR TITLE
✨ (#487) 프로젝트 파일 조회 방식을 커서 페이지네이션에서 전체 조회로 변경

### DIFF
--- a/src/features/file/api/fileApi.ts
+++ b/src/features/file/api/fileApi.ts
@@ -2,11 +2,9 @@ import type { FileSummaryResponse } from '@/features/file/types/fileApiTypes';
 import api from '@/shared/api/axiosInstance';
 
 export const fileApi = {
-  // 프로젝트 파일 목록 조회 (커서 기반 페이지네이션)
-  fetchFiles: async (projectId: string, cursor?: string, limit = 8) => {
-    const { data } = await api.get(`/projects/${projectId}/files`, {
-      params: { cursor, limit },
-    });
+  // 프로젝트 파일 목록 조회
+  fetchFiles: async (projectId: string) => {
+    const { data } = await api.get(`/projects/${projectId}/files`);
     return data;
   },
   deleteFile: async (fileId: string) => {

--- a/src/features/file/components/FileSection.tsx
+++ b/src/features/file/components/FileSection.tsx
@@ -41,7 +41,11 @@ const FileSection = () => {
           <TableBody>
             {currentData.length > 0 ? (
               currentData.map((file, index) => (
-                <FileTableRow key={file.id} file={file} index={currentPage * pageSize + index} />
+                <FileTableRow
+                  key={file.fileId}
+                  file={file}
+                  index={currentPage * pageSize + index}
+                />
               ))
             ) : (
               <FileTableEmpty />

--- a/src/features/file/components/FileSection.tsx
+++ b/src/features/file/components/FileSection.tsx
@@ -13,8 +13,7 @@ import { FILE_HEADER_HEIGHT, FILE_ROW_HEIGHT } from '@/features/file/constants/f
 const FileSection = () => {
   const { projectId } = useParams<{ projectId: string }>();
   const tableContainerRef = useRef<HTMLDivElement>(null);
-  const { data, isLoading, error } = useProjectFilesQuery(projectId!);
-  const allFiles = data?.pages.flatMap((page) => page.files) ?? [];
+  const { data: allFiles = [], isLoading, error } = useProjectFilesQuery(projectId!);
   const { currentPage, setCurrentPage, pageSize, pageCount, currentData } = usePagination({
     data: allFiles,
     containerRef: tableContainerRef,
@@ -42,11 +41,7 @@ const FileSection = () => {
           <TableBody>
             {currentData.length > 0 ? (
               currentData.map((file, index) => (
-                <FileTableRow
-                  key={file.fileId}
-                  file={file}
-                  index={currentPage * pageSize + index}
-                />
+                <FileTableRow key={file.id} file={file} index={currentPage * pageSize + index} />
               ))
             ) : (
               <FileTableEmpty />

--- a/src/features/file/components/FileTableRow.tsx
+++ b/src/features/file/components/FileTableRow.tsx
@@ -23,7 +23,7 @@ const FileTableRow = ({ file, index }: FileTableRowProps) => {
   const mobileHiddenClass = 'hidden md:table-cell';
   const commonCellClass = '!label2-regular sm:!body2-regular text-gray-600';
   const handleNavigate = () => navigate(ROUTES.TASK_DETAIL(projectData.id, file.taskId));
-  const handleDownload = () => downloadFile({ fileId: file.fileId, fileName: file.filename });
+  const handleDownload = () => downloadFile({ fileId: file.id, fileName: file.filename });
   return (
     <TableRow className="bg-white border-b border-gray-100 hover:bg-boost-blue/5 transition-colors duration-150 h-[54px]">
       <TableCell className={cn('pl-6 text-center', commonCellClass)}>{index + 1}</TableCell>

--- a/src/features/file/components/FileTableRow.tsx
+++ b/src/features/file/components/FileTableRow.tsx
@@ -23,7 +23,7 @@ const FileTableRow = ({ file, index }: FileTableRowProps) => {
   const mobileHiddenClass = 'hidden md:table-cell';
   const commonCellClass = '!label2-regular sm:!body2-regular text-gray-600';
   const handleNavigate = () => navigate(ROUTES.TASK_DETAIL(projectData.id, file.taskId));
-  const handleDownload = () => downloadFile({ fileId: file.id, fileName: file.filename });
+  const handleDownload = () => downloadFile({ fileId: file.fileId, fileName: file.filename });
   return (
     <TableRow className="bg-white border-b border-gray-100 hover:bg-boost-blue/5 transition-colors duration-150 h-[54px]">
       <TableCell className={cn('pl-6 text-center', commonCellClass)}>{index + 1}</TableCell>

--- a/src/features/file/components/FileTableRow.tsx
+++ b/src/features/file/components/FileTableRow.tsx
@@ -53,7 +53,7 @@ const FileTableRow = ({ file, index }: FileTableRowProps) => {
           variant="link"
           className="p-0 text-gray-700 hover:text-boost-blue flex items-center gap-1 body2-regular h-auto max-w-[180px]"
         >
-          <span className="truncate">{file.taskName || '할 일로 이동'}</span>
+          <span className="truncate">할 일로 이동</span>
           <ChevronRight className="w-3.5 h-3.5 flex-shrink-0" />
         </Button>
       </TableCell>

--- a/src/features/file/hooks/useProjectFilesQuery.ts
+++ b/src/features/file/hooks/useProjectFilesQuery.ts
@@ -1,14 +1,11 @@
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { fileApi } from '@/features/file/api/fileApi';
-import type { ProjectFilesResponse } from '@/features/file/types/fileApiTypes';
+import type { ProjectFile } from '@/features/file/types/fileApiTypes';
 
 export const useProjectFilesQuery = (projectId: string) => {
-  return useInfiniteQuery<ProjectFilesResponse, Error>({
+  return useQuery<ProjectFile[], Error>({
     queryKey: ['projectFiles', projectId],
-    queryFn: ({ pageParam }) =>
-      fileApi.fetchFiles(projectId, typeof pageParam === 'string' ? pageParam : undefined, 50),
-    getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.nextCursor : undefined),
+    queryFn: () => fileApi.fetchFiles(projectId),
     enabled: !!projectId,
-    initialPageParam: undefined,
   });
 };

--- a/src/features/file/hooks/useProjectFilesQuery.ts
+++ b/src/features/file/hooks/useProjectFilesQuery.ts
@@ -1,9 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
 import { fileApi } from '@/features/file/api/fileApi';
-import type { ProjectFile } from '@/features/file/types/fileApiTypes';
+import type { ProjectFilesResponse } from '@/features/file/types/fileApiTypes';
 
 export const useProjectFilesQuery = (projectId: string) => {
-  return useQuery<ProjectFile[], Error>({
+  return useQuery<ProjectFilesResponse, Error>({
     queryKey: ['projectFiles', projectId],
     queryFn: () => fileApi.fetchFiles(projectId),
     enabled: !!projectId,

--- a/src/features/file/types/fileApiTypes.ts
+++ b/src/features/file/types/fileApiTypes.ts
@@ -8,7 +8,7 @@ export interface FileDownloadUrlResponse {
 }
 
 export interface ProjectFile {
-  fileId: string;
+  id: string;
   filename: string;
   contentType: string;
   type: string;

--- a/src/features/file/types/fileApiTypes.ts
+++ b/src/features/file/types/fileApiTypes.ts
@@ -6,25 +6,17 @@ export interface FileDownloadUrlResponse {
   headers: Record<string, string>;
   expiresInSeconds: number;
 }
-
 export interface ProjectFile {
-  id: string;
+  fileId: string;
+  taskId: string;
   filename: string;
   contentType: string;
   type: string;
   completedAt: string;
   sizeBytes: number;
-  taskId: string;
-  taskName: string;
 }
+export type ProjectFilesResponse = ProjectFile[];
 
-export interface ProjectFilesResponse {
-  projectId: string;
-  files: ProjectFile[];
-  count: number;
-  nextCursor: string | null;
-  hasNext: boolean;
-}
 export interface FileSummaryResponse {
   totalCount: number;
   totalSizeBytes: number;


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약

- 프로젝트 파일 조회 방식을 커서 페이지네이션에서 전체 조회로 변경했습니다.

### ✨ 작업 내용
- 프로젝트 파일 API 응답 구조 변경에 따라 조회 방식을 수정했습니다.
- useInfiniteQuery → useQuery로 변경
- 필드명 변경 반영 : fileId → id 


**데스크탑**
<img width="1919" height="866" alt="image" src="https://github.com/user-attachments/assets/3f050f43-1441-4770-872f-6bfd04ea051b" />

**모바일**
<img width="520" height="796" alt="image" src="https://github.com/user-attachments/assets/d828c88d-3f02-4905-95fe-9e10b5c9939e" />

### ❗ 참고 사항(선택)

- X

### #️⃣ 연관 이슈

- Close #487 
