### PR TITLE
🐛 (#490) iOS에서 가이드가 표시되지 않는 문제 해결

### DIFF
--- a/src/pages/AlarmSetupMobilePage.tsx
+++ b/src/pages/AlarmSetupMobilePage.tsx
@@ -39,8 +39,8 @@ const AlarmSetupMobilePage = () => {
 
   const getDisabledReason = (): DisabledReasonType | null => {
     if (!isQrValid) return 'INVALID_QR';
-    if (!isWebPushSupported) return 'NOT_SUPPORTED';
     if (isIOSNotStandalone) return 'IOS_NOT_STANDALONE';
+    if (!isWebPushSupported) return 'NOT_SUPPORTED';
     return null;
   };
 
@@ -52,13 +52,11 @@ const AlarmSetupMobilePage = () => {
       hasShownError.current = true;
       return;
     }
-
-    if (!isWebPushSupported) {
-      toast.error('이 브라우저는 알림 기능을 지원하지 않습니다.');
+    if (isIOSNotStandalone) {
       return;
     }
-
-    if (isIOSNotStandalone) {
+    if (!isWebPushSupported) {
+      toast.error('이 브라우저는 알림 기능을 지원하지 않습니다.');
       return;
     }
 


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약

- iOS에서 가이드가 표시되지 않는 문제 해결

### ✨ 작업 내용
- disableReason 계산 순서 문제로 인해 발생한 문제로 보입니다. 
- 아래와 같이 구현되어 있어, isIOSNotStandalone이어도 그보다 먼저 !isWebPushSupported가 true이면 NOT_SUPPORTED로 처리되는 문제가 있었습니다.
```
const getDisabledReason = (): DisabledReasonType | null => {
  if (!isQrValid) return 'INVALID_QR';
  if (!isWebPushSupported) return 'NOT_SUPPORTED';
  if (isIOSNotStandalone) return 'IOS_NOT_STANDALONE';
  return null;
};
```

### ❗ 참고 사항

- 확인해보고 혹시 문제가 계속되면 다시 수정해보겠습니다!

### #️⃣ 연관 이슈

- Close #490
