### PR TITLE
🐛(#485, #486) CommentDrawer 관련 버그 해결

### DIFF
--- a/src/features/ai-transform/components/AiTransformConfirmModal/AiTransformConfirmModalContent.tsx
+++ b/src/features/ai-transform/components/AiTransformConfirmModal/AiTransformConfirmModalContent.tsx
@@ -48,7 +48,8 @@ const AiTransformConfirmModalContent = () => {
     }
   };
 
-  const handleCancelClick = () => {
+  const handleCancelClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
     resetModal();
     useAiTransformStore.getState().reset();
   };

--- a/src/features/ai-transform/components/AiTransformSelectModal/AiTransformSelectModalContent.tsx
+++ b/src/features/ai-transform/components/AiTransformSelectModal/AiTransformSelectModalContent.tsx
@@ -15,10 +15,10 @@ const AiTransformSelectModalContent = () => {
   const { resetModal } = useModal();
 
   const [hoveredSide, setHoveredSide] = useState<AiCommentSide>(AI_COMMENT_SIDE.DEFAULT);
+  const handleSelect = (e: React.MouseEvent, type: AiCommentSide) => {
+    e.stopPropagation();
 
-  const handleSelect = (type: AiCommentSide) => {
     const text = type === AI_COMMENT_SIDE.ORIGIN ? originalText : transformedText;
-
     if (!text) return;
 
     setSelectedText(text);
@@ -26,7 +26,6 @@ const AiTransformSelectModalContent = () => {
     if (type === AI_COMMENT_SIDE.TRANSFORM) {
       setIsAnonymous(true);
       setPersona(PERSONA.BOO);
-
       toast.success('댓글이 반영되었어요!');
     }
 
@@ -41,7 +40,7 @@ const AiTransformSelectModalContent = () => {
           text={originalText}
           isHovered={hoveredSide === AI_COMMENT_SIDE.ORIGIN}
           onHover={setHoveredSide}
-          onSelect={() => handleSelect(AI_COMMENT_SIDE.ORIGIN)}
+          onSelect={(e) => handleSelect(e, AI_COMMENT_SIDE.ORIGIN)}
         />
 
         <AiTransformGuide hoveredSide={hoveredSide} />
@@ -51,7 +50,7 @@ const AiTransformSelectModalContent = () => {
           text={transformedText}
           isHovered={hoveredSide === AI_COMMENT_SIDE.TRANSFORM}
           onHover={setHoveredSide}
-          onSelect={() => handleSelect(AI_COMMENT_SIDE.TRANSFORM)}
+          onSelect={(e) => handleSelect(e, AI_COMMENT_SIDE.TRANSFORM)}
         />
       </div>
     </div>

--- a/src/features/ai-transform/components/AiTransformSelectModal/AiTransformTextCard.tsx
+++ b/src/features/ai-transform/components/AiTransformSelectModal/AiTransformTextCard.tsx
@@ -2,11 +2,12 @@ import { Button } from '@/shared/components/shadcn/button';
 import { cn } from '@/shared/lib/utils';
 import { AI_COMMENT_SIDE } from '@/features/ai-transform/constants/ai-transform.ui.constants';
 import type { AiCommentSide } from '@/features/ai-transform/types/ai-transform.ui.types';
+import type React from 'react';
 
 interface AiTransformTextCardProps {
   type: AiCommentSide;
   text: string | null;
-  onSelect: () => void;
+  onSelect: (e: React.MouseEvent) => void;
   onHover: (side: AiCommentSide) => void;
   isHovered: boolean;
 }

--- a/src/features/task-detail/components/CommentSection/CommentDrawerMobile.tsx
+++ b/src/features/task-detail/components/CommentSection/CommentDrawerMobile.tsx
@@ -20,7 +20,6 @@ const CommentDrawerMobile = ({
     <Drawer
       open={isCommentOpen}
       onOpenChange={(open) => {
-        console.log('Drawer onOpenChange:', open);
         setIsCommentOpen(open);
       }}
     >

--- a/src/features/task-detail/components/CommentSection/CommentDrawerMobile.tsx
+++ b/src/features/task-detail/components/CommentSection/CommentDrawerMobile.tsx
@@ -17,7 +17,13 @@ const CommentDrawerMobile = ({
   comments,
 }: CommentDrawerMobileProps) => {
   return (
-    <Drawer open={isCommentOpen} onOpenChange={setIsCommentOpen}>
+    <Drawer
+      open={isCommentOpen}
+      onOpenChange={(open) => {
+        console.log('Drawer onOpenChange:', open);
+        setIsCommentOpen(open);
+      }}
+    >
       <DrawerContent className="h-[90vh]">
         <div className="flex-1 overflow-y-auto px-1">
           <CommentSection projectId={projectId!} taskId={taskId!} comments={comments} />

--- a/src/features/task-detail/components/CommentSection/CommentList/CommentItem.tsx
+++ b/src/features/task-detail/components/CommentSection/CommentList/CommentItem.tsx
@@ -50,7 +50,9 @@ const CommentItem = forwardRef<HTMLDivElement, CommentItemProps>(
       onCommentSelect?.(comment.fileInfo ?? null);
       setActivePinCommentId(comment.commentId);
       clearCurrentPin();
-      closeCommentDrawer();
+      if (comment.fileInfo) {
+        closeCommentDrawer();
+      }
     };
 
     return (

--- a/src/pages/TaskDetailPage.tsx
+++ b/src/pages/TaskDetailPage.tsx
@@ -11,7 +11,8 @@ import TaskDetailCommentSection from '@/features/task-detail/components/TaskDeta
 import CommentDrawerMobile from '@/features/task-detail/components/CommentSection/CommentDrawerMobile';
 import { useShallow } from 'zustand/react/shallow';
 import TaskReviewActionCollapsible from '@/features/task-detail/components/TaskReviewActionCollapsible';
-import { useIsMobile } from './../shared/hooks/use-mobile';
+import { useIsMobile } from '@/shared/hooks/use-mobile';
+
 const TaskDetailPage = () => {
   const { projectId, taskId } = useParams<{ projectId: string; taskId: string }>();
   const { data: comments = [] } = useCommentQuery(projectId!, taskId!);

--- a/src/pages/TaskDetailPage.tsx
+++ b/src/pages/TaskDetailPage.tsx
@@ -11,6 +11,7 @@ import TaskDetailCommentSection from '@/features/task-detail/components/TaskDeta
 import CommentDrawerMobile from '@/features/task-detail/components/CommentSection/CommentDrawerMobile';
 import { useShallow } from 'zustand/react/shallow';
 import TaskReviewActionCollapsible from '@/features/task-detail/components/TaskReviewActionCollapsible';
+import { useIsMobile } from './../shared/hooks/use-mobile';
 const TaskDetailPage = () => {
   const { projectId, taskId } = useParams<{ projectId: string; taskId: string }>();
   const { data: comments = [] } = useCommentQuery(projectId!, taskId!);
@@ -25,6 +26,14 @@ const TaskDetailPage = () => {
 
   const extractedPins = useMemo(() => extractPinsFromComments(comments), [comments]);
   const [isReviewActionOpen, setIsReviewActionOpen] = useState(false);
+  const isMobile = useIsMobile();
+
+  useEffect(() => {
+    if (!isMobile && isCommentDrawerOpen) {
+      setCommentDrawerOpen(false);
+    }
+  }, [isMobile, isCommentDrawerOpen, setCommentDrawerOpen]);
+
   useEffect(() => {
     setPins(extractedPins);
   }, [extractedPins, setPins]);
@@ -49,14 +58,16 @@ const TaskDetailPage = () => {
         <TaskDetailCommentSection projectId={projectId!} taskId={taskId!} comments={comments} />
       </div>
 
-      <div className="sm:hidden">
-        <CommentDrawerMobile
-          isCommentOpen={isCommentDrawerOpen}
-          setIsCommentOpen={setCommentDrawerOpen}
-          projectId={projectId}
-          taskId={taskId}
-          comments={comments}
-        />
+      <div>
+        {isMobile && (
+          <CommentDrawerMobile
+            isCommentOpen={isCommentDrawerOpen}
+            setIsCommentOpen={setCommentDrawerOpen}
+            projectId={projectId}
+            taskId={taskId}
+            comments={comments}
+          />
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약
-  모바일 → 데스크탑 전환 시 CommentDrawer 유지되는 문제 해결했습니다
-  모달 닫기 시 터치 이벤트가 전파되어 CommentDrawer가 닫히는 문제 해결했습니다.
 
### ✨ 작업 내용
 **1. 모바일 → 데스크탑 전환 시 CommentDrawer 유지되는 문제 해결**
- useIsMobile 사용해서 모바일일때만 유지되도록 수정했습니다!

**2. 모달 닫기 시 터치 이벤트가 전파되어 CommentDrawer가 닫히는 문제 해결**
- 모바일 환경에서 모달 내부 클릭 시 터치 이벤트가 전파되면서 CommentDrawer에서 outside interaction으로 인식되어 닫히는 문제로 확인했습니다.
- 따라서 모달 내부에서 클릭했을 때 이벤트가 전파되지 않도록  stopPropagation()를 두었습니다.

### ❗ 참고 사항(선택)

- X

### #️⃣ 연관 이슈

- Close #485 #486