### PR TITLE
🐛 (#498) StatusView 레이아웃 어긋나는 문제 수정

### DIFF
--- a/src/features/webpush/components/StatusView.tsx
+++ b/src/features/webpush/components/StatusView.tsx
@@ -19,11 +19,16 @@ const StatusView = ({
   textClass,
   children,
 }: StatusViewProps) => (
-  <div className="flex flex-col h-screen justify-center items-center text-center p-6 space-y-6">
-    <div className="relative inline-block">
-      <div className={cn('absolute inset-0 rounded-full blur-xs', blurClass)} />
-      <div className={cn('relative p-4 rounded-full w-fit mx-auto', bgClass)}>
-        <Icon className={cn('w-10 h-10', textClass)} />
+  <div className="flex min-h-[100dvh] flex-col items-center justify-center p-6 text-center space-y-6">
+    <div className="relative flex h-18 w-18 items-center justify-center">
+      <div className={cn('absolute inset-0 rounded-full blur-md', blurClass)} />
+      <div
+        className={cn(
+          'relative z-10 flex h-18 w-18 items-center justify-center rounded-full',
+          bgClass,
+        )}
+      >
+        <Icon className={cn('h-10 w-10', textClass)} />
       </div>
     </div>
 


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약

- StatusView 레이아웃 어긋나는 문제 수정

### ✨ 작업 내용

- 아이콘 컨테이너 크기를 고정(h-18 w-18)하여 블러와 배경 정렬 일치하도록 수정했습니다.
- h-screen → min-h-[100dvh]로 변경하여 상단바가 내려왔을 때도 대응 가능하도록 수정했습니다. 

### ❗ 참고 사항(선택)

-  X

### #️⃣ 연관 이슈

- Close #498
