### PR TITLE
🐛✨ (#508) 요청 큐잉을 적용해 Access Token 만료 시 다중 재발급 요청으로 인한 로그아웃 문제 해결

### DIFF
--- a/src/shared/api/axiosInstance.ts
+++ b/src/shared/api/axiosInstance.ts
@@ -48,8 +48,9 @@ api.interceptors.response.use(
 
     const status = error.response.status;
 
-    if (status === 401 && !originalRequest._retry)
+    if (status === 401 && originalRequest && !originalRequest._retry) {
       return handleUnauthorizedRequest(originalRequest);
+    }
 
     if (status >= 500) {
       Sentry.withScope((scope) => {

--- a/src/shared/api/interceptors/handleUnauthorizedRequest.ts
+++ b/src/shared/api/interceptors/handleUnauthorizedRequest.ts
@@ -1,5 +1,5 @@
-import axios, { isAxiosError, type AxiosRequestConfig } from 'axios';
-import { apiPublic } from '@/shared/api/axiosInstance';
+import { isAxiosError, type AxiosRequestConfig, type AxiosResponse } from 'axios';
+import { api, apiPublic } from '@/shared/api/axiosInstance';
 import { ApiError } from '@/shared/error/types/apiError.types';
 import { useAuthStore } from '@/features/auth/store/useAuthStore';
 
@@ -7,26 +7,86 @@ interface AxiosRequestConfigWithRetry extends AxiosRequestConfig {
   _retry?: boolean;
 }
 
+interface QueueItem {
+  resolve: (value: AxiosResponse) => void;
+  reject: (reason?: unknown) => void;
+  originalRequest: AxiosRequestConfigWithRetry;
+}
+
+let isRefreshing = false;
+let requestQueue: QueueItem[] = [];
+
+// 첫번째 요청에 대한 재발급 성공/실패시 requestQueue에 있는 나머지 요청을 실행
+const processQueue = async (error: unknown, accessToken?: string) => {
+  const queue = [...requestQueue];
+  requestQueue = [];
+
+  for (const item of queue) {
+    // 실패시 (첫번째 재발급이 실패)
+    if (error || !accessToken) {
+      item.reject(error);
+      continue;
+    }
+
+    try {
+      if (!item.originalRequest.headers) {
+        item.originalRequest.headers = {};
+      }
+
+      item.originalRequest.headers.Authorization = `Bearer ${accessToken}`;
+      const response = await api(item.originalRequest);
+      item.resolve(response);
+    } catch (requestError) {
+      if (isAxiosError(requestError)) {
+        item.reject(new ApiError(requestError));
+        continue;
+      }
+
+      item.reject(requestError);
+    }
+  }
+};
 export const handleUnauthorizedRequest = async (originalRequest: AxiosRequestConfigWithRetry) => {
   originalRequest._retry = true;
 
+  if (isRefreshing) {
+    return new Promise<AxiosResponse>((resolve, reject) => {
+      requestQueue.push({
+        resolve,
+        reject,
+        originalRequest,
+      });
+    });
+  }
+
+  isRefreshing = true;
+
   try {
-    const { data } = await apiPublic.post(`/auth/reissue`, {}, { withCredentials: true });
+    const { data } = await apiPublic.post('/auth/reissue', {}, { withCredentials: true });
     const newAccessToken = data.accessToken;
 
     useAuthStore.getState().setAuth({ accessToken: newAccessToken });
 
-    if (!originalRequest.headers) originalRequest.headers = {};
+    await processQueue(null, newAccessToken);
+
+    if (!originalRequest.headers) {
+      originalRequest.headers = {};
+    }
 
     originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
 
-    return axios(originalRequest);
+    return api(originalRequest);
   } catch (error) {
-    const clearAuth = useAuthStore.getState().clearAuth;
-    clearAuth();
+    await processQueue(error);
 
-    if (isAxiosError(error)) return Promise.reject(new ApiError(error));
+    useAuthStore.getState().clearAuth();
+
+    if (isAxiosError(error)) {
+      return Promise.reject(new ApiError(error));
+    }
 
     return Promise.reject(error);
+  } finally {
+    isRefreshing = false;
   }
 };

--- a/src/shared/api/interceptors/handleUnauthorizedRequest.ts
+++ b/src/shared/api/interceptors/handleUnauthorizedRequest.ts
@@ -16,13 +16,11 @@ interface QueueItem {
 let isRefreshing = false;
 let requestQueue: QueueItem[] = [];
 
-// 첫번째 요청에 대한 재발급 성공/실패시 requestQueue에 있는 나머지 요청을 실행
 const processQueue = async (error: unknown, accessToken?: string) => {
   const queue = [...requestQueue];
   requestQueue = [];
 
   for (const item of queue) {
-    // 실패시 (첫번째 재발급이 실패)
     if (error || !accessToken) {
       item.reject(error);
       continue;


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약

- 요청 큐잉을 적용해 Access Token 만료 시 다중 재발급 요청으로 인한 로그아웃 문제 해결

### ✨ 작업 내용

- 401 응답 발생 시 요청마다 재발급을 시도하던 기존 구조를 개선했습니다.
- 전역 상태(isRefreshing)를 통해 재발급 요청을 단 1회만 수행하도록 변경했습니다.
- 재발급 진행 중 발생하는 401 요청들은 queue에 저장했습니다. 
- 재발급 성공 시 : 새로운 access token을 적용하여 queue에 쌓인 요청들을 재요청
- 재발급 실패 시 : queue에 쌓인 요청들을 모두 reject 처리, 로그인 상태 초기화 (clearAuth)

## 적용 전 흐름
<img width="769" height="362" alt="스크린샷 2026-04-02 182418" src="https://github.com/user-attachments/assets/c9140a4e-4c69-4e1b-838c-52b98eefd19a" />

**- 여러 API가 동시에 401을 받음  -> 여러개의 /auth/reissue를 호출** 

- refresh token 이 일부 요청에서 재발급에 실패하고 
- 실패시 clearAuth()가 실행되어 로그인 상태가 초기화되었습니다.

> 1. access token 만료
> 2. 인증 필요한 API 여러 개가 동시에 호출
> 3. 전부 401 반환
> 4. 각 요청이 각각 /auth/reissue 호출
> 5. refresh token이 rotation 방식이면
> 6. 첫 번째 재발급은 성공
> 7. 두 번째, 세 번째 재발급은 이미 refresh token이 갱신돼서 실패
> 8. 실패한 쪽에서 이 코드 실행
> ```js
> const clearAuth = useAuthStore.getState().clearAuth;
> clearAuth();
> ```
> 9. 결국 이미 한 번 성공해서 새 access token을 받았더라도, 실패한 재발급 때문에 로그인 상태가 지워짐
> 10. 재발급에 성공했어도 로그인이 풀리는 현상 발생


## 적용 후 흐름
<img width="452" height="518" alt="스크린샷 2026-04-02 230943" src="https://github.com/user-attachments/assets/5391f4b4-6ce8-433d-ae0b-759fc204abfb" />

**- 여러 API가 동시에 401을 받음 -> 1개의  /auth/reissue 요청**

> 1. 여러 API가 동시에 401을 받음
> 2. 맨 처음 1개만 /auth/reissue 요청 (isRefreshing=false 일때 )
> 3. 나머지 401 요청들은 `requestQueue`에 넣음  (isRefreshing=true 일때 )
> 4. 재발급 성공하면
> 5. 새 access token 저장
> 6. 큐에 있던 요청들에 새 토큰 넣어서 다시 요청(resolve) -> access token 만료되어도 로그인이 풀리지 않음
> 7. 재발급 실패하면
> 8. 대기 중이던 요청들도 전부 실패(reject) 처리
> 9. 그때만 로그아웃

### ❗ 참고 사항(선택)

- 로컬에서 테스트 했을 때는 정상작동 하는 것을 확인했습니다. 
- 위에 첨부한 사진이 prod 환경 local 환경으로 다릅니다. 아래 설명 참고해서 봐주시면 감사하겠습니다! 

### #️⃣ 연관 이슈

- Close #508
