### PR TITLE
♻️ (#507, #510) 파일 업로드, 다운로드 및 삭제 에러 처리 구조 개선 및 조회 404 버그 해결

### DIFF
--- a/src/features/file/components/FileTableHeader.tsx
+++ b/src/features/file/components/FileTableHeader.tsx
@@ -2,23 +2,22 @@ import { TableHeader, TableRow, TableHead } from '@/shared/components/shadcn/tab
 import { cn } from '@/shared/lib/utils';
 
 const FileTableHeader = () => {
-  const mobileHiddenClass = 'hidden md:table-cell';
+  const mobileHiddenClass = 'hidden sm:table-cell';
+  const tabletHiddenClass = 'hidden lg:table-cell';
   const headClass = 'subtitle2-bold text-gray-800';
 
   return (
     <TableHeader className="sticky top-0 z-10 bg-white">
       <TableRow className="border-b border-gray-300 h-12 hover:bg-white">
-        <TableHead className="w-[50px] pl-6 subtitle2-bold text-gray-800 text-center">
-          번호
-        </TableHead>
-        <TableHead className={cn('min-w-[150px] pl-4 text-left', headClass)}>파일명</TableHead>
-        <TableHead className={cn('w-[100px] text-left', headClass, mobileHiddenClass)}>
+        <TableHead className="w-[80px] subtitle2-bold text-gray-800 text-center">번호</TableHead>
+        <TableHead className={cn('min-w-[150px] text-left', headClass)}>파일명</TableHead>
+        <TableHead className={cn('w-[120px] text-left', headClass, mobileHiddenClass)}>
           용량
         </TableHead>
-        <TableHead className={cn('w-[180px] text-left', headClass, mobileHiddenClass)}>
+        <TableHead className={cn('w-[200px] text-left', headClass, tabletHiddenClass)}>
           업로드일
         </TableHead>
-        <TableHead className={cn('w-[200px] text-left', headClass, mobileHiddenClass)}>
+        <TableHead className={cn('w-[120px] lg:w-[200px] text-left', headClass, mobileHiddenClass)}>
           연결된 할 일
         </TableHead>
         <TableHead className={cn('w-[100px] text-center', headClass, mobileHiddenClass)}>

--- a/src/features/file/components/FileTableRow.tsx
+++ b/src/features/file/components/FileTableRow.tsx
@@ -1,14 +1,17 @@
+import { useNavigate } from 'react-router-dom';
+import toast from 'react-hot-toast';
+import { Download, ChevronRight } from 'lucide-react';
+import { ROUTES } from '@/app/routes/routeHelpers';
+import { cn } from '@/shared/lib/utils';
+import { formatDateTime } from '@/shared/utils/dateUtils';
 import { TableRow, TableCell } from '@/shared/components/shadcn/table';
 import { Button } from '@/shared/components/shadcn/button';
-import { Download, ChevronRight } from 'lucide-react';
+import { ApiError } from '@/shared/error/types/apiError.types';
+import { getErrorMessage } from '@/shared/error/utils/error.utils';
 import { formatBytes, getFileIcon } from '@/features/file/utils/fileUtils';
 import { useFileDownloadMutation } from '@/features/file/hooks/useFileDownloadMutation';
-import { formatDateTime } from '@/shared/utils/dateUtils';
 import type { ProjectFile } from '@/features/file/types/fileApiTypes';
-import { useNavigate } from 'react-router-dom';
-import { ROUTES } from '@/app/routes/routeHelpers';
 import { useProjectStore } from '@/features/project/store/useProjectStore';
-import { cn } from '@/shared/lib/utils';
 import FileMobileActionMenu from '@/features/file/components/FileMobileActionMenu';
 
 interface FileTableRowProps {
@@ -17,23 +20,41 @@ interface FileTableRowProps {
 }
 
 const FileTableRow = ({ file, index }: FileTableRowProps) => {
-  const projectData = useProjectStore((state) => state.projectData);
-  const { mutate: downloadFile } = useFileDownloadMutation();
   const navigate = useNavigate();
-  const mobileHiddenClass = 'hidden md:table-cell';
+  const projectData = useProjectStore((s) => s.projectData);
+
+  const { mutate: downloadFile } = useFileDownloadMutation();
+
+  const mobileHiddenClass = 'hidden sm:table-cell';
+  const tabletHiddenClass = 'hidden lg:table-cell';
   const commonCellClass = '!label2-regular sm:!body2-regular text-gray-600';
+
   const handleNavigate = () => navigate(ROUTES.TASK_DETAIL(projectData.id, file.taskId));
-  const handleDownload = () => downloadFile({ fileId: file.fileId, fileName: file.filename });
+  const handleDownloadFile = () => {
+    downloadFile(
+      { fileId: file.fileId, fileName: file.filename },
+      {
+        onSuccess: () => {
+          toast.success('파일이 다운로드 되었습니다.');
+        },
+        onError: (error) => {
+          if (error instanceof ApiError) toast.error(getErrorMessage(error));
+          else toast.error('파일 다운로드를 실패했습니다.');
+        },
+      },
+    );
+  };
+
   return (
     <TableRow className="bg-white border-b border-gray-100 hover:bg-boost-blue/5 transition-colors duration-150 h-[54px]">
-      <TableCell className={cn('pl-6 text-center', commonCellClass)}>{index + 1}</TableCell>
+      <TableCell className={cn('text-center', commonCellClass)}>{index + 1}</TableCell>
 
       <TableCell className="max-w-0">
         <div className="flex items-center gap-3 h-full">
           <img
             src={getFileIcon(file.contentType)}
             alt="file-icon"
-            className="hidden sm:block w-5 h-5 flex-shrink-0"
+            className="w-5 h-5 flex-shrink-0"
           />
           <span className="truncate body2-regular text-gray-900">{file.filename}</span>
         </div>
@@ -43,7 +64,7 @@ const FileTableRow = ({ file, index }: FileTableRowProps) => {
         {formatBytes(file.sizeBytes)}
       </TableCell>
 
-      <TableCell className={cn(commonCellClass, mobileHiddenClass)}>
+      <TableCell className={cn(commonCellClass, tabletHiddenClass)}>
         {formatDateTime(file.completedAt)}
       </TableCell>
 
@@ -51,7 +72,7 @@ const FileTableRow = ({ file, index }: FileTableRowProps) => {
         <Button
           onClick={handleNavigate}
           variant="link"
-          className="p-0 text-gray-700 hover:text-boost-blue flex items-center gap-1 body2-regular h-auto max-w-[180px]"
+          className="!p-0 text-gray-700 hover:text-boost-blue flex items-center gap-1 body2-regular h-auto max-w-[180px]"
         >
           <span className="truncate">할 일로 이동</span>
           <ChevronRight className="w-3.5 h-3.5 flex-shrink-0" />
@@ -60,7 +81,7 @@ const FileTableRow = ({ file, index }: FileTableRowProps) => {
 
       <TableCell className={cn('text-center', mobileHiddenClass)}>
         <Button
-          onClick={handleDownload}
+          onClick={handleDownloadFile}
           variant="ghost"
           size="sm"
           className="w-9 h-9 p-0 text-gray-500 hover:text-gray-900 hover:bg-gray-100 rounded-full"
@@ -69,8 +90,8 @@ const FileTableRow = ({ file, index }: FileTableRowProps) => {
         </Button>
       </TableCell>
 
-      <TableCell className="sm:hidden text-center">
-        <FileMobileActionMenu onNavigate={handleNavigate} onDownload={handleDownload} />
+      <TableCell className="sm:hidden text-end">
+        <FileMobileActionMenu onNavigate={handleNavigate} onDownload={handleDownloadFile} />
       </TableCell>
     </TableRow>
   );

--- a/src/features/file/hooks/useFileDownloadMutation.ts
+++ b/src/features/file/hooks/useFileDownloadMutation.ts
@@ -1,20 +1,12 @@
 import { useMutation } from '@tanstack/react-query';
 import { fetchFileDownloadUrl } from '@/features/file/api/fileDownloadApi';
 import { downloadFromS3 } from '@/features/file/utils/fileDownloadUtil';
-import toast from 'react-hot-toast';
 
 export const useFileDownloadMutation = () => {
   return useMutation({
     mutationFn: async ({ fileId, fileName }: { fileId: string; fileName: string }) => {
       const presigned = await fetchFileDownloadUrl(fileId);
-      //다운로드
       await downloadFromS3(presigned.url, presigned.headers, fileName);
-    },
-    onSuccess: () => {
-      toast.success('파일이 다운로드 되었습니다.');
-    },
-    onError: () => {
-      toast.error('파일 다운로드에 실패했습니다.');
     },
   });
 };

--- a/src/features/task-detail/components/FileSection/FileItem.tsx
+++ b/src/features/task-detail/components/FileSection/FileItem.tsx
@@ -1,5 +1,8 @@
-import fileIcon from '@/shared/assets/images/file-icon/file-icon.png';
+import toast from 'react-hot-toast';
 import { EllipsisVertical } from 'lucide-react';
+import fileIcon from '@/shared/assets/images/file-icon/file-icon.png';
+import { ApiError } from '@/shared/error/types/apiError.types';
+import { getErrorMessage } from '@/shared/error/utils/error.utils';
 import { FileStatusImages } from '@/features/task-detail/utils/fileStatusImageUtil';
 import {
   DropdownMenu,
@@ -10,26 +13,39 @@ import {
 } from '@/shared/components/shadcn/dropdown-menu';
 import { useFileDownloadMutation } from '@/features/file/hooks/useFileDownloadMutation';
 import type { FileItemType } from '@/features/file/types/fileTypes';
+
 interface FileItemProps extends FileItemType {
-  onOpenPdf: (fileUrl: string) => void;
-  onDelete: () => void;
-  onDownload?: () => void;
+  onOpenPdf: () => void;
+  onDeleteFile: () => void;
 }
 
 const FileItem = ({
   fileId,
   fileName,
-  fileUrl,
   onOpenPdf,
-  onDelete,
+  onDeleteFile,
   fileSize,
   timeLeft,
   status,
 }: FileItemProps) => {
-  const handleOpenPdf = () => {
-    if (onOpenPdf) onOpenPdf(fileUrl);
-  };
   const { mutate: downloadFile } = useFileDownloadMutation();
+
+  const handleOpenPdf = () => onOpenPdf();
+  const handleDeleteFile = () => onDeleteFile();
+  const handleDownloadFile = () => {
+    downloadFile(
+      { fileId: fileId, fileName: fileName },
+      {
+        onSuccess: () => {
+          toast.success('파일이 다운로드 되었습니다.');
+        },
+        onError: (error) => {
+          if (error instanceof ApiError) toast.error(getErrorMessage(error));
+          else toast.error('파일 다운로드에 실패했습니다.');
+        },
+      },
+    );
+  };
 
   return (
     <div
@@ -60,7 +76,7 @@ const FileItem = ({
               <DropdownMenuItem
                 onClick={(e) => {
                   e.stopPropagation();
-                  downloadFile({ fileId, fileName });
+                  handleDownloadFile();
                 }}
                 className="px-4 py-2 !label2-regular sm:!label1-regular text-gray-800 hover:bg-gray-200 cursor-pointer"
               >
@@ -69,7 +85,7 @@ const FileItem = ({
               <DropdownMenuItem
                 onClick={(e) => {
                   e.stopPropagation();
-                  if (onDelete) onDelete();
+                  handleDeleteFile();
                 }}
                 className="px-4 py-2 !label2-regular sm:!label1-regular text-red-600 hover:bg-gray-200 cursor-pointer"
               >

--- a/src/features/task-detail/components/FileSection/FileSection.tsx
+++ b/src/features/task-detail/components/FileSection/FileSection.tsx
@@ -9,23 +9,25 @@ import { useTaskFilesQuery } from '@/features/task-detail/hooks/query/useTaskFil
 import { useDeleteFileMutation } from '@/features/task-detail/hooks/mutation/useDeleteFileMutation';
 import { FileUploadAction } from '@/features/task-detail/components/FileSection/FileUploadAction';
 import { fileToast } from '@/features/task-detail/utils/toast/fileToast';
-import { useTaskDetailStore } from '@/features/task-detail/store/useTaskDetailStore';
+import { useProjectStore } from '@/features/project/store/useProjectStore';
+import type { ServerFileType } from '@/features/task-detail/types/fileApiTypes';
 
 interface FileSectionProps {
   onOpenPdf: (url: string, fileName: string, id: string) => void;
   taskId: string;
+  files: ServerFileType[];
 }
 
-const FileSection = ({ onOpenPdf, taskId }: FileSectionProps) => {
-  const { data: uiFiles } = useTaskFilesQuery(taskId);
-  const { mutate: deleteFile } = useDeleteFileMutation(taskId);
-  const removeFile = useTaskDetailStore((s) => s.removeFile);
+const FileSection = ({ onOpenPdf, taskId, files }: FileSectionProps) => {
+  const projectData = useProjectStore((s) => s.projectData);
+
+  const { data: uiFiles } = useTaskFilesQuery(taskId, files);
+  const { mutate: deleteFile } = useDeleteFileMutation(projectData.id, taskId);
 
   const handleDeleteFile = (fileId: string) => {
     deleteFile(fileId, {
       onSuccess: () => {
         fileToast.deleteSuccess();
-        removeFile(fileId);
       },
       onError: (error) => {
         if (error instanceof ApiError) toast.error(getErrorMessage(error));

--- a/src/features/task-detail/components/FileSection/FileSection.tsx
+++ b/src/features/task-detail/components/FileSection/FileSection.tsx
@@ -1,21 +1,38 @@
+import { Suspense } from 'react';
 import { Link } from 'lucide-react';
+import toast from 'react-hot-toast';
+import { ApiError } from '@/shared/error/types/apiError.types';
+import { getErrorMessage } from '@/shared/error/utils/error.utils';
+import ContentItem from '@/shared/components/ui/ContentItem';
 import FileItem from '@/features/task-detail/components/FileSection/FileItem';
 import { useTaskFilesQuery } from '@/features/task-detail/hooks/query/useTaskFilesQuery';
-import type { ServerFileType } from '@/features/task-detail/types/fileApiTypes';
-import ContentItem from '@/shared/components/ui/ContentItem';
 import { useDeleteFileMutation } from '@/features/task-detail/hooks/mutation/useDeleteFileMutation';
-import { Suspense } from 'react';
 import { FileUploadAction } from '@/features/task-detail/components/FileSection/FileUploadAction';
+import { fileToast } from '@/features/task-detail/utils/toast/fileToast';
+import { useTaskDetailStore } from '@/features/task-detail/store/useTaskDetailStore';
 
 interface FileSectionProps {
   onOpenPdf: (url: string, fileName: string, id: string) => void;
   taskId: string;
-  files: ServerFileType[];
 }
 
-const FileSection = ({ onOpenPdf, taskId, files: serverFiles }: FileSectionProps) => {
-  const { data: uiFiles } = useTaskFilesQuery(serverFiles, taskId);
+const FileSection = ({ onOpenPdf, taskId }: FileSectionProps) => {
+  const { data: uiFiles } = useTaskFilesQuery(taskId);
   const { mutate: deleteFile } = useDeleteFileMutation(taskId);
+  const removeFile = useTaskDetailStore((s) => s.removeFile);
+
+  const handleDeleteFile = (fileId: string) => {
+    deleteFile(fileId, {
+      onSuccess: () => {
+        fileToast.deleteSuccess();
+        removeFile(fileId);
+      },
+      onError: (error) => {
+        if (error instanceof ApiError) toast.error(getErrorMessage(error));
+        else fileToast.deleteError();
+      },
+    });
+  };
 
   return (
     <div className="w-full h-full pt-6 p-3 pb-4 border-t-2 border-gray-300 flex flex-col">
@@ -37,7 +54,7 @@ const FileSection = ({ onOpenPdf, taskId, files: serverFiles }: FileSectionProps
             fileUrl={item.fileUrl}
             fileSize={item.fileSize}
             timeLeft={item.timeLeft}
-            onDelete={() => deleteFile(item.fileId)}
+            onDeleteFile={() => handleDeleteFile(item.fileId)}
             onOpenPdf={() => onOpenPdf(item.fileUrl, item.fileName, item.fileId)}
             status={item.status}
           />

--- a/src/features/task-detail/components/FileSection/FileUploadAction.tsx
+++ b/src/features/task-detail/components/FileSection/FileUploadAction.tsx
@@ -1,14 +1,24 @@
 import { Upload } from 'lucide-react';
 import { useDropzone } from 'react-dropzone';
+import toast from 'react-hot-toast';
+import { ApiError } from '@/shared/error/types/apiError.types';
+import { getErrorMessage } from '@/shared/error/utils/error.utils';
 import { useUploadFileMutation } from '@/features/task-detail/hooks/mutation/useFileUploadUrlMutation';
-import { fileToast } from '@/features/task-detail/utils/toast/fileToast';
 
 export function FileUploadAction({ taskId }: { taskId: string }) {
   const { mutate: uploadFile } = useUploadFileMutation();
 
   const onDrop = (acceptedFiles: File[]) => {
     acceptedFiles.forEach((file) => {
-      uploadFile({ file, taskId }, { onError: (e) => fileToast.uploadError(e) });
+      uploadFile(
+        { file, taskId },
+        {
+          onError: (error) => {
+            if (error instanceof ApiError) toast.error(getErrorMessage(error));
+            else toast.error('파일 업로드를 실패했어요.');
+          },
+        },
+      );
     });
   };
 

--- a/src/features/task-detail/components/TaskDetailInfoSection.tsx
+++ b/src/features/task-detail/components/TaskDetailInfoSection.tsx
@@ -1,4 +1,4 @@
-import { lazy, useEffect } from 'react';
+import { lazy } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useTaskDetailStore } from '@/features/task-detail/store/useTaskDetailStore';
 import FileSection from '@/features/task-detail/components/FileSection/FileSection';
@@ -12,18 +12,13 @@ interface TaskDetailInfoSectionProps {
 }
 
 const TaskDetailInfoSection = ({ task, taskId }: TaskDetailInfoSectionProps) => {
-  const { isPdfOpen, setSelectedFile, togglePdf, setFiles } = useTaskDetailStore(
+  const { isPdfOpen, setSelectedFile, togglePdf } = useTaskDetailStore(
     useShallow((s) => ({
       isPdfOpen: s.isPdfOpen,
       setSelectedFile: s.setSelectedFile,
       togglePdf: s.togglePdf,
-      setFiles: s.setFiles,
     })),
   );
-
-  useEffect(() => {
-    setFiles(task.files);
-  }, [task.files, setFiles]);
 
   return (
     <div className="w-full flex flex-col sm:w-6/10 overflow-hidden">
@@ -37,6 +32,7 @@ const TaskDetailInfoSection = ({ task, taskId }: TaskDetailInfoSectionProps) => 
 
           <section id="file" className="h-4/12">
             <FileSection
+              files={task.files}
               taskId={taskId ?? ''}
               onOpenPdf={(url, name, id) => {
                 setSelectedFile({ fileId: id, fileName: name, fileUrl: url });

--- a/src/features/task-detail/components/TaskDetailInfoSection.tsx
+++ b/src/features/task-detail/components/TaskDetailInfoSection.tsx
@@ -1,8 +1,8 @@
+import { lazy, useEffect } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { useTaskDetailStore } from '@/features/task-detail/store/useTaskDetailStore';
 import FileSection from '@/features/task-detail/components/FileSection/FileSection';
 import TaskDetailContent from '@/features/task-detail/components/TaskDetailContent/TaskDetailContent';
-import { useShallow } from 'zustand/react/shallow';
-import { lazy } from 'react';
 import type { TaskDetail } from '@/features/task/types/task.domain.types';
 const PDFViewer = lazy(() => import('@/features/task-detail/components/PdfViewer/PdfViewer'));
 
@@ -12,13 +12,19 @@ interface TaskDetailInfoSectionProps {
 }
 
 const TaskDetailInfoSection = ({ task, taskId }: TaskDetailInfoSectionProps) => {
-  const { isPdfOpen, setSelectedFile, togglePdf } = useTaskDetailStore(
+  const { isPdfOpen, setSelectedFile, togglePdf, setFiles } = useTaskDetailStore(
     useShallow((s) => ({
       isPdfOpen: s.isPdfOpen,
       setSelectedFile: s.setSelectedFile,
       togglePdf: s.togglePdf,
+      setFiles: s.setFiles,
     })),
   );
+
+  useEffect(() => {
+    setFiles(task.files);
+  }, [task.files, setFiles]);
+
   return (
     <div className="w-full flex flex-col sm:w-6/10 overflow-hidden">
       {isPdfOpen ? (
@@ -31,7 +37,6 @@ const TaskDetailInfoSection = ({ task, taskId }: TaskDetailInfoSectionProps) => 
 
           <section id="file" className="h-4/12">
             <FileSection
-              files={task.files}
               taskId={taskId ?? ''}
               onOpenPdf={(url, name, id) => {
                 setSelectedFile({ fileId: id, fileName: name, fileUrl: url });

--- a/src/features/task-detail/hooks/mutation/useDeleteFileMutation.ts
+++ b/src/features/task-detail/hooks/mutation/useDeleteFileMutation.ts
@@ -2,8 +2,9 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { fileApi } from '@/features/file/api/fileApi';
 import type { FileItemType } from '@/features/file/types/fileTypes';
 import { TASK_DETAIL_FILES_QUERY_KEY } from '@/features/task-detail/constants/taskDetailQueryKey';
+import { TASK_QUERY_KEYS } from '@/features/task/constants/task.query.constants';
 
-export const useDeleteFileMutation = (taskId: string) => {
+export const useDeleteFileMutation = (projectId: string, taskId: string) => {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -32,6 +33,7 @@ export const useDeleteFileMutation = (taskId: string) => {
 
     onSettled: async () => {
       await queryClient.invalidateQueries({ queryKey: TASK_DETAIL_FILES_QUERY_KEY.list(taskId) });
+      await queryClient.invalidateQueries({ queryKey: TASK_QUERY_KEYS.detail(projectId, taskId) });
     },
   });
 };

--- a/src/features/task-detail/hooks/mutation/useDeleteFileMutation.ts
+++ b/src/features/task-detail/hooks/mutation/useDeleteFileMutation.ts
@@ -2,7 +2,6 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { fileApi } from '@/features/file/api/fileApi';
 import type { FileItemType } from '@/features/file/types/fileTypes';
 import { TASK_DETAIL_FILES_QUERY_KEY } from '@/features/task-detail/constants/taskDetailQueryKey';
-import { fileToast } from '@/features/task-detail/utils/toast/fileToast';
 
 export const useDeleteFileMutation = (taskId: string) => {
   const queryClient = useQueryClient();
@@ -25,15 +24,10 @@ export const useDeleteFileMutation = (taskId: string) => {
       return { prevFiles };
     },
 
-    onSuccess: () => {
-      fileToast.deleteSuccess();
-    },
-
     onError: (_error, _fileId, context) => {
       if (context?.prevFiles) {
         queryClient.setQueryData(TASK_DETAIL_FILES_QUERY_KEY.list(taskId), context.prevFiles);
       }
-      fileToast.deleteError();
     },
 
     onSettled: async () => {

--- a/src/features/task-detail/hooks/query/useTaskFilesQuery.ts
+++ b/src/features/task-detail/hooks/query/useTaskFilesQuery.ts
@@ -1,15 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
 import { TASK_DETAIL_FILES_QUERY_KEY } from '@/features/task-detail/constants/taskDetailQueryKey';
 import { mapToFileItemWithDownloadUrl } from '@/features/task-detail/utils/mapToFileItemWithDownloadUrl';
-import { useTaskDetailStore } from '@/features/task-detail/store/useTaskDetailStore';
+import type { ServerFileType } from '@/features/task-detail/types/fileApiTypes';
 
-export const useTaskFilesQuery = (taskId: string) => {
-  const files = useTaskDetailStore((s) => s.files);
-
+export const useTaskFilesQuery = (taskId: string, serverFiles: ServerFileType[]) => {
   return useQuery({
     queryKey: TASK_DETAIL_FILES_QUERY_KEY.list(taskId),
-    queryFn: () => Promise.all(files.map(mapToFileItemWithDownloadUrl)),
+    queryFn: () => Promise.all(serverFiles.map(mapToFileItemWithDownloadUrl)),
     placeholderData: [],
-    enabled: files.length > 0,
+    enabled: serverFiles.length > 0,
   });
 };

--- a/src/features/task-detail/hooks/query/useTaskFilesQuery.ts
+++ b/src/features/task-detail/hooks/query/useTaskFilesQuery.ts
@@ -1,13 +1,15 @@
 import { useQuery } from '@tanstack/react-query';
-import type { ServerFileType } from '@/features/task-detail/types/fileApiTypes';
 import { TASK_DETAIL_FILES_QUERY_KEY } from '@/features/task-detail/constants/taskDetailQueryKey';
 import { mapToFileItemWithDownloadUrl } from '@/features/task-detail/utils/mapToFileItemWithDownloadUrl';
+import { useTaskDetailStore } from '@/features/task-detail/store/useTaskDetailStore';
 
-export const useTaskFilesQuery = (serverFiles: ServerFileType[], taskId: string) => {
+export const useTaskFilesQuery = (taskId: string) => {
+  const files = useTaskDetailStore((s) => s.files);
+
   return useQuery({
     queryKey: TASK_DETAIL_FILES_QUERY_KEY.list(taskId),
-    queryFn: async () => Promise.all(serverFiles.map(mapToFileItemWithDownloadUrl)),
+    queryFn: () => Promise.all(files.map(mapToFileItemWithDownloadUrl)),
     placeholderData: [],
-    enabled: !!serverFiles?.length,
+    enabled: files.length > 0,
   });
 };

--- a/src/features/task-detail/hooks/ui/useFileUploader.ts
+++ b/src/features/task-detail/hooks/ui/useFileUploader.ts
@@ -1,20 +1,25 @@
 import { useDropzone } from 'react-dropzone';
+import toast from 'react-hot-toast';
+import { ApiError } from '@/shared/error/types/apiError.types';
+import { getErrorMessage } from '@/shared/error/utils/error.utils';
 import { useUploadFileMutation } from '@/features/task-detail/hooks/mutation/useFileUploadUrlMutation';
-import { fileToast } from '@/features/task-detail/utils/toast/fileToast';
 
 export const useFileUploader = (taskId: string) => {
   const { mutate: uploadFile } = useUploadFileMutation();
+
   const onDrop = (acceptedFiles: File[]) => {
     acceptedFiles.forEach((file) => {
       uploadFile(
         { file, taskId },
         {
-          onError: (e) => {
-            fileToast.uploadError(e);
+          onError: (error) => {
+            if (error instanceof ApiError) toast.error(getErrorMessage(error));
+            else toast.error('파일 업로드를 실패했어요.');
           },
         },
       );
     });
   };
+
   return useDropzone({ onDrop });
 };

--- a/src/features/task-detail/store/useTaskDetailStore.ts
+++ b/src/features/task-detail/store/useTaskDetailStore.ts
@@ -6,6 +6,7 @@ import type {
   TaskDetailDataState,
   TaskDetailState,
 } from '@/features/task-detail/types/TaskDetailStore.types';
+import type { ServerFileType } from '@/features/task-detail/types/fileApiTypes';
 import { create } from 'zustand';
 import type { StateCreator } from 'zustand';
 
@@ -22,13 +23,26 @@ const initialDataState: TaskDetailDataState = {
   editingComment: null,
   persona: null,
   isCommentDrawerOpen: false,
+  files: [],
 };
 
 // 파일 관련 Slice
-const createFileSlice: StateCreator<TaskDetailState, [], [], FileSlice> = (set) => ({
+const createFileSlice: StateCreator<
+  TaskDetailState,
+  [],
+  [],
+  FileSlice & {
+    files: ServerFileType[];
+    setFiles: (files: ServerFileType[]) => void;
+    removeFile: (fileId: string) => void;
+  }
+> = (set) => ({
   selectedFile: initialDataState.selectedFile,
+  files: initialDataState.files,
 
   setSelectedFile: (selectedFile) => set({ selectedFile }),
+  setFiles: (files) => set({ files }),
+  removeFile: (fileId) => set((state) => ({ files: state.files.filter((f) => f.id !== fileId) })),
 
   clearFileState: () =>
     set({
@@ -39,6 +53,7 @@ const createFileSlice: StateCreator<TaskDetailState, [], [], FileSlice> = (set) 
       isAnonymous: false,
       activePinCommentId: null,
       selectedCommentId: null,
+      files: [],
     }),
 });
 
@@ -61,7 +76,7 @@ const createPdfSlice: StateCreator<TaskDetailState, [], [], PdfSlice> = (set) =>
   togglePdf: (isPdfOpen) => set({ isPdfOpen }),
 });
 
-//댓글 관련 Slice
+// 댓글 관련 Slice
 const createCommentSlice: StateCreator<TaskDetailState, [], [], CommentSlice> = (set) => ({
   isAnonymous: initialDataState.isAnonymous,
   selectedCommentId: initialDataState.selectedCommentId,

--- a/src/features/task-detail/store/useTaskDetailStore.ts
+++ b/src/features/task-detail/store/useTaskDetailStore.ts
@@ -6,7 +6,6 @@ import type {
   TaskDetailDataState,
   TaskDetailState,
 } from '@/features/task-detail/types/TaskDetailStore.types';
-import type { ServerFileType } from '@/features/task-detail/types/fileApiTypes';
 import { create } from 'zustand';
 import type { StateCreator } from 'zustand';
 
@@ -23,26 +22,13 @@ const initialDataState: TaskDetailDataState = {
   editingComment: null,
   persona: null,
   isCommentDrawerOpen: false,
-  files: [],
 };
 
 // 파일 관련 Slice
-const createFileSlice: StateCreator<
-  TaskDetailState,
-  [],
-  [],
-  FileSlice & {
-    files: ServerFileType[];
-    setFiles: (files: ServerFileType[]) => void;
-    removeFile: (fileId: string) => void;
-  }
-> = (set) => ({
+const createFileSlice: StateCreator<TaskDetailState, [], [], FileSlice> = (set) => ({
   selectedFile: initialDataState.selectedFile,
-  files: initialDataState.files,
 
   setSelectedFile: (selectedFile) => set({ selectedFile }),
-  setFiles: (files) => set({ files }),
-  removeFile: (fileId) => set((state) => ({ files: state.files.filter((f) => f.id !== fileId) })),
 
   clearFileState: () =>
     set({
@@ -53,7 +39,6 @@ const createFileSlice: StateCreator<
       isAnonymous: false,
       activePinCommentId: null,
       selectedCommentId: null,
-      files: [],
     }),
 });
 

--- a/src/features/task-detail/types/TaskDetailStore.types.ts
+++ b/src/features/task-detail/types/TaskDetailStore.types.ts
@@ -1,5 +1,6 @@
 import type { PersonaType } from '@/features/comment/constants/personaConstants';
 import type { FileInfo, PinWithAuthor } from '@/features/task-detail/types/taskDetailType';
+import type { ServerFileType } from '@/features/task-detail/types/fileApiTypes';
 
 type EditingCommentState = {
   id: string;
@@ -20,6 +21,7 @@ export type TaskDetailDataState = {
   editingComment: EditingCommentState | null;
   persona: PersonaType | null;
   isCommentDrawerOpen: boolean;
+  files: ServerFileType[];
 };
 
 type TaskDetailActions = {
@@ -39,6 +41,8 @@ type TaskDetailActions = {
   clearCurrentPin: () => void;
   clearFileState: () => void;
   resetAll: () => void;
+  setFiles: (files: ServerFileType[]) => void;
+  removeFile: (fileId: string) => void;
 };
 
 export type TaskDetailState = TaskDetailDataState & TaskDetailActions;
@@ -46,8 +50,9 @@ export type TaskDetailState = TaskDetailDataState & TaskDetailActions;
 // Slice 타입
 export type FileSlice = Pick<
   TaskDetailState,
-  'selectedFile' | 'setSelectedFile' | 'clearFileState'
+  'selectedFile' | 'setSelectedFile' | 'clearFileState' | 'files' | 'setFiles' | 'removeFile'
 >;
+
 export type PinSlice = Pick<
   TaskDetailState,
   | 'currentPin'
@@ -58,7 +63,9 @@ export type PinSlice = Pick<
   | 'setIsEditingPin'
   | 'clearCurrentPin'
 >;
+
 export type PdfSlice = Pick<TaskDetailState, 'isPdfOpen' | 'togglePdf'>;
+
 export type CommentSlice = Pick<
   TaskDetailState,
   | 'isAnonymous'

--- a/src/features/task-detail/types/TaskDetailStore.types.ts
+++ b/src/features/task-detail/types/TaskDetailStore.types.ts
@@ -1,6 +1,5 @@
 import type { PersonaType } from '@/features/comment/constants/personaConstants';
 import type { FileInfo, PinWithAuthor } from '@/features/task-detail/types/taskDetailType';
-import type { ServerFileType } from '@/features/task-detail/types/fileApiTypes';
 
 type EditingCommentState = {
   id: string;
@@ -21,7 +20,6 @@ export type TaskDetailDataState = {
   editingComment: EditingCommentState | null;
   persona: PersonaType | null;
   isCommentDrawerOpen: boolean;
-  files: ServerFileType[];
 };
 
 type TaskDetailActions = {
@@ -41,8 +39,6 @@ type TaskDetailActions = {
   clearCurrentPin: () => void;
   clearFileState: () => void;
   resetAll: () => void;
-  setFiles: (files: ServerFileType[]) => void;
-  removeFile: (fileId: string) => void;
 };
 
 export type TaskDetailState = TaskDetailDataState & TaskDetailActions;
@@ -50,7 +46,7 @@ export type TaskDetailState = TaskDetailDataState & TaskDetailActions;
 // Slice 타입
 export type FileSlice = Pick<
   TaskDetailState,
-  'selectedFile' | 'setSelectedFile' | 'clearFileState' | 'files' | 'setFiles' | 'removeFile'
+  'selectedFile' | 'setSelectedFile' | 'clearFileState'
 >;
 
 export type PinSlice = Pick<


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약

- 파일 업로드, 다운로드 및 삭제 에러 처리 구조 개선했습니다.

<br/>

### ✨ 작업 내용

#### 1. 파일 목록 페이지 태블릿 반응형 추가
- 파일 목록 페이지에 태블릿 반응형을 추가했습니다.
- 미세하게 cell 들 너비 조절 했습니다.
<img width="500" alt="image" src="https://github.com/user-attachments/assets/38eff80c-1139-447a-9103-e1dbfc674ef2" />
<img width="500" alt="image" src="https://github.com/user-attachments/assets/eac82a4a-30a7-4908-8178-4743ea7df427" />
<img width="500" alt="image" src="https://github.com/user-attachments/assets/2e461060-c529-491e-b41a-0e04be70d344" />

<br/>

#### 2. 파일 삭제 후 404 에러
- 파일 삭제 후 파일 목록 내 파일들 download url 조회에서 404 에러가 반복적으로 발생하는 부분이 있어 이를 store로 해결해두었습니다.
- 자세한 에러 내용 및 이미지는 아래 이슈 확인해주세요
- #510 

<br/>

#### 3. 파일 삭제, 업로드, 다운로드 에러 처리 구조 개선
- 사용자 피드백에서 상세한 에러 내용 없이 예기치 못한 이유로 파일 업로드에 실패했다고만 떠서 이를 상세한 에러 메세지가 나올 수 있도록 했습니다.
- 기존에 구현해주신 fileToast는 일단 성공, 삭제 정도에서 사용해두었고 추후 error type 파일 리팩터링할 때 fileToast 부분도 같이 정리해서 사용할 수 있도록 리팩터링 진행하겠습니다.
<img width="400" height="983" alt="image" src="https://github.com/user-attachments/assets/387236ed-3062-4fce-893b-bbdb32f5a6be" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/f90afe15-8130-4584-a950-5b7af3217c59" />

<br/>
<br/>

### ❗ 참고 사항

- 일단 삭제 후 삭제가 완료된 파일 목록 배열? 로 조회가 안 되는 거 같아 일단은 store로 해결했으나 query 훅 내에서 store을 구독하는 형태가 좀 아닌 듯 하여 추후 리팩터링하여 개선하겠습니다. 

<br/>

### #️⃣ 연관 이슈

- Close #507, #510
