### PR TITLE
🚸 (#515) 담당자가 아니어도 할 일 수정/삭제 가능하도록 변경

### DIFF
--- a/src/app/error/root-error/RootFallback.tsx
+++ b/src/app/error/root-error/RootFallback.tsx
@@ -1,3 +1,6 @@
+import { AlertCircle } from 'lucide-react';
+import { ROUTE_PATH } from '@/app/routes/routePaths';
+import { useRouteError, isRouteErrorResponse, useNavigate } from 'react-router-dom';
 import { Button } from '@/shared/components/shadcn/button';
 import {
   Card,
@@ -6,10 +9,10 @@ import {
   CardTitle,
   CardDescription,
 } from '@/shared/components/shadcn/card';
-import { AlertCircle } from 'lucide-react';
-import { useRouteError, isRouteErrorResponse } from 'react-router-dom';
 
 export default function RootFallback() {
+  const navigate = useNavigate();
+
   const error = useRouteError();
   let message = '알 수 없는 오류가 발생했습니다.';
 
@@ -20,6 +23,8 @@ export default function RootFallback() {
   }
 
   const handleRefresh = () => window.location.reload();
+  const handleGoHome = () => navigate(ROUTE_PATH.MAIN);
+  const handleGoBack = () => navigate(-1);
 
   return (
     <div className="flex min-h-screen items-center justify-center p-6">
@@ -32,9 +37,17 @@ export default function RootFallback() {
 
         <CardContent className="space-y-6 text-center">
           <p className="label1-regular text-gray-500 whitespace-pre-wrap">{message}</p>
-          <Button variant="defaultBoost" className="w-full" onClick={handleRefresh}>
-            다시 시도
-          </Button>
+          <div className="flex flex-col gap-2">
+            <Button variant="defaultBoost" className="w-full" onClick={handleRefresh}>
+              다시 시도
+            </Button>
+            <Button variant="secondaryBoost" className="w-full" onClick={handleGoBack}>
+              뒤로
+            </Button>
+            <Button variant="secondary" className="w-full" onClick={handleGoHome}>
+              홈으로 이동
+            </Button>
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/src/features/board/hooks/useTaskDrag.ts
+++ b/src/features/board/hooks/useTaskDrag.ts
@@ -8,7 +8,10 @@ import {
   type DragMoveEvent,
 } from '@dnd-kit/core';
 import { useRef, useState, useEffect } from 'react';
+import toast from 'react-hot-toast';
 import { useQueryClient } from '@tanstack/react-query';
+import { ApiError } from '@/shared/error/types/apiError.types';
+import { getErrorMessage } from '@/shared/error/utils/error.utils';
 import {
   useMoveTaskMutation,
   optimisticallyMoveTask,
@@ -133,7 +136,12 @@ export const useTaskDrag = ({
         };
 
         pendingScrollRef.current = toStatus;
-        moveTaskMutation.mutate(params);
+        moveTaskMutation.mutate(params, {
+          onError: (error) => {
+            if (error instanceof ApiError) toast.error(getErrorMessage(error));
+            else toast.error('할 일 이동 중 오류가 발생했습니다.');
+          },
+        });
       }
     }
 

--- a/src/features/task-detail/components/TaskDetailContent/TaskDetailContent.tsx
+++ b/src/features/task-detail/components/TaskDetailContent/TaskDetailContent.tsx
@@ -1,8 +1,10 @@
+import toast from 'react-hot-toast';
 import { useNavigate, useParams } from 'react-router-dom';
 import { ROUTES } from '@/app/routes/routeHelpers';
-import { useAuthStore } from '@/features/auth/store/useAuthStore';
-import { useDeleteTaskMutation } from '@/features/task/hooks/mutation/useDeleteTaskMutation';
+import { ApiError } from '@/shared/error/types/apiError.types';
+import { getErrorMessage } from '@/shared/error/utils/error.utils';
 import { useModal } from '@/shared/hooks/useModal';
+import { useDeleteTaskMutation } from '@/features/task/hooks/mutation/useDeleteTaskMutation';
 import StatusInfo from '@/features/task-detail/components/TaskDetailContent/StatusInfo';
 import DescriptionArea from '@/features/task-detail/components/TaskDetailContent/DescriptionArea';
 import AssigneeSection from '@/features/task-detail/components/TaskDetailContent/AssigneeMoreList';
@@ -22,27 +24,22 @@ const TaskDetailContent = ({ task }: TaskDetailContentProps) => {
   const { showCustom, resetModal } = useModal();
 
   const { mutateAsync: deleteTaskMutation } = useDeleteTaskMutation(projectId || '');
-  const currentUser = useAuthStore((state) => state.user);
 
-  if (!projectId) {
-    console.error('Project ID가 없습니다!');
-    return null;
-  }
+  if (!projectId) return null;
 
-  const currentUserId = currentUser?.id;
-  const isAssignee = task.assignees?.some((assignee) => assignee.id === currentUserId);
-
-  const handleDelete = async () => {
+  const handleDeleteTask = async () => {
     try {
       await deleteTaskMutation({ taskId: task.id, status: task.status });
       resetModal();
       navigate(ROUTES.PROJECT_BOARD(projectId));
-    } catch (err) {
-      console.error('할 일 삭제 실패:', err);
+      toast.success('할 일이 삭제되었어요.');
+    } catch (error) {
+      if (error instanceof ApiError) toast.error(getErrorMessage(error));
+      else toast.error('할 일 삭제를 실패했어요.');
     }
   };
 
-  const handleEdit = () => {
+  const handleEditTask = () => {
     showCustom({
       title: '할 일 수정',
       size: 'lg',
@@ -53,7 +50,7 @@ const TaskDetailContent = ({ task }: TaskDetailContentProps) => {
 
   return (
     <div className="relative flex flex-col h-full overflow-hidden bg-gray-100">
-      {isAssignee && <TaskControlDropdown onClickDelete={handleDelete} onEdit={handleEdit} />}
+      <TaskControlDropdown onClickDelete={handleDeleteTask} onEdit={handleEditTask} />
 
       <div className="flex flex-col flex-1  p-3 sm:p-4 gap-2 sm:gap-4 overflow-hidden">
         <div className="px-2.5">

--- a/src/features/task/hooks/mutation/useMoveTaskMutation.ts
+++ b/src/features/task/hooks/mutation/useMoveTaskMutation.ts
@@ -3,8 +3,6 @@ import { taskApi } from '@/features/task/api/taskApi';
 import { arrayMove } from '@dnd-kit/sortable';
 import type { TaskListResponse } from '@/features/task/types/task.query.types';
 import type { TaskListItem, TaskDetail, TaskStatus } from '@/features/task/types/task.domain.types';
-import { isAxiosError } from 'axios';
-import toast from 'react-hot-toast';
 import { TASK_QUERY_KEYS } from '@/features/task/constants/task.query.constants';
 import type { Direction, SortBy } from '@/features/board/types/board.sort.types';
 import { useBoardSearchStore } from '@/features/board/store/useBoardSearchStore';
@@ -152,7 +150,7 @@ export const useMoveTaskMutation = () => {
       return optimisticallyMoveTask(queryClient, variables);
     },
 
-    onError: (error, variables, context) => {
+    onError: (_, variables, context) => {
       const { fromStatus, toStatus, projectId, activeTaskId } = variables;
 
       const getQueryKeyLocal = (status: TaskStatus) => getQueryKey(status, variables);
@@ -167,18 +165,6 @@ export const useMoveTaskMutation = () => {
           TASK_QUERY_KEYS.detail(projectId, activeTaskId),
           context.previousTaskDetail,
         );
-
-      if (isAxiosError(error) && error.response?.status === 403) {
-        toast.error('담당자만 가능해요!');
-        return;
-      }
-      if (isAxiosError(error) && error.response?.status === 400) {
-        toast.error('아직 승인이 완료되지 않았어요!');
-        return;
-      }
-
-      console.error(error);
-      alert('할 일 이동 중 오류가 발생했습니다.');
     },
 
     onSettled: (_data, _error, variables) => {

--- a/src/shared/components/ui/form/AssigneeDropdown.tsx
+++ b/src/shared/components/ui/form/AssigneeDropdown.tsx
@@ -9,7 +9,6 @@ import {
 } from '@/shared/components/shadcn/dropdown-menu';
 import { Checkbox } from '@/shared/components/shadcn/checkbox';
 import { Avatar, AvatarImage } from '@/shared/components/shadcn/avatar';
-import { cn } from '@/shared/lib/utils';
 import type { Member } from '@/features/user/types/userTypes';
 import { getAvatarSrc } from '@/features/avatar-picker/utils/avatarUtils';
 
@@ -37,14 +36,14 @@ const AssigneeDropdown = ({
           {assignees.length ? assignees.join(', ') : '담당자를 선택하세요'}
         </span>
         {assignees.length > 0 && (
-          <span className="ml-2 bg-blue-100 text-boost-blue px-2 py-0.5 rounded-full text-xs font-medium">
+          <span className=" bg-blue-100 text-boost-blue px-1.5 py-0.5 rounded-full label2-bold">
             {assignees.length}
           </span>
         )}
       </Button>
     </DropdownMenuTrigger>
     <DropdownMenuContent className="min-w-[300px] border-gray-300 shadow-sm">
-      <DropdownMenuLabel className="text-xs text-gray-500">팀 멤버</DropdownMenuLabel>
+      <DropdownMenuLabel className="!label2-regular text-gray-500">팀 멤버</DropdownMenuLabel>
       <DropdownMenuSeparator />
       {members?.map((member) => {
         const isChecked = assignees.includes(member.name);
@@ -57,21 +56,19 @@ const AssigneeDropdown = ({
           >
             <Checkbox
               checked={isChecked}
-              className={cn(
-                'data-[state=checked]:bg-boost-blue data-[state=checked]:border-boost-blue',
-              )}
+              className="data-[state=checked]:bg-boost-blue data-[state=checked]:border-boost-blue"
             />
 
             <Avatar
               style={{ backgroundColor: member.backgroundColor }}
-              className={cn('flex items-center h-6 w-6 rounded-full shrink-0 shadow-xs')}
+              className="flex items-center h-6 w-6 rounded-full shrink-0 shadow-xs"
             >
               <AvatarImage
                 src={getAvatarSrc(member)}
                 className="h-5 w-5 object-cover rounded-full mx-auto my-auto"
               />
             </Avatar>
-            <span className="font-medium text-sm">{member.name}</span>
+            <span className="label1-regular">{member.name}</span>
           </DropdownMenuItem>
         );
       })}


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약

- 담당자가 아니어도 할 일을 수정, 삭제할 수 있도록 변경했습니다.

<br/>

### ✨ 작업 내용

- 내부적으로 논의 후, 담당자가 아니어도 할 일을 수정, 삭제할 수 있도록 하자는 의견이 채택되어 작업한 사항입니다.
- 403 에러 처리를 하던 부분을 삭제하여 따로 분기 + 에러 처리를 하지 않도록 했습니다.
- 기존 할 일 상세 페이지에서 해당 할 일의 담당자일 때만 보이던 수정/삭제 드롭다운 버튼이 항상 보이도록 수정하여 모두가 수정/삭제 할 수 있도록 했습니다.

<br/>

### ❗ 참고 사항(선택)

- 테스트 진행해보니, 담당자가 아니어도 할 일 상태 변경 (드래그 앤 드랍)도 잘 되고, 수정 삭제도 잘 되는 것으로 확인 완료했습니다.
- 해당 작업은 QA에서 테스트 진행 후 4월 4일 배포할 예정입니다.

<br/>

### #️⃣ 연관 이슈

- Close #515 
