### PR TITLE
🐛 (#519) 모바일 알림 설정 페이지 상태 전환 시 UI 잔상 문제 해결

### DIFF
--- a/src/features/webpush/constants/alarmStatusContent.tsx
+++ b/src/features/webpush/constants/alarmStatusContent.tsx
@@ -14,6 +14,7 @@ const CREATED_CONTENT = {
   bgClass: 'bg-boost-blue/20',
   textClass: 'text-boost-blue-pressed',
 } as const;
+
 const REGISTERED_CONTENT = {
   icon: CheckCircle,
   title: '설정 완료!',
@@ -22,6 +23,7 @@ const REGISTERED_CONTENT = {
   bgClass: 'bg-green-50',
   textClass: 'text-green-500',
 };
+
 export const STATUS_CONTENT = {
   CREATED: CREATED_CONTENT,
   CONNECTED: CREATED_CONTENT,

--- a/src/features/webpush/hooks/useAlarmSetup.ts
+++ b/src/features/webpush/hooks/useAlarmSetup.ts
@@ -7,6 +7,7 @@ import { WebPushStatus } from '@/features/webpush/types/pushApiTypes';
 import { webPushToast } from '@/features/webpush/utils/toast/webPushToast';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+
 export const useAlarmSetup = () => {
   const navigate = useNavigate();
   const location = useLocation();
@@ -25,10 +26,13 @@ export const useAlarmSetup = () => {
       webPushToast.connectFailed();
     },
   });
+
   const { data: statusData } = usePushSessionStatusQuery(data?.token);
   const { mutate: enableServiceAlarm } = useEnableServiceAlarmMutation();
+
   const [expiryTimestamp, setExpiryTimestamp] = useState<number | null>(null);
   const [remainingTime, setRemainingTime] = useState(REFRESH_INTERVAL_MS / 1000);
+
   // QR 데이터 URL 생성
   const qrData = data?.token
     ? `${window.location.origin}${ROUTE_PATH.ALARM_SETUP_MOBILE}?token=${data.token}`
@@ -57,19 +61,24 @@ export const useAlarmSetup = () => {
 
   useEffect(() => {
     if (!expiryTimestamp) return;
+
     const updateTimer = () => {
       const now = Date.now();
       const diff = Math.max(0, Math.floor((expiryTimestamp - now) / 1000));
       setRemainingTime(diff);
     };
+
     updateTimer();
+
     const countdownInterval = setInterval(updateTimer, 1000);
+
     return () => clearInterval(countdownInterval);
   }, [expiryTimestamp]);
 
   const minutes = Math.floor(remainingTime / 60);
   const seconds = Math.floor(remainingTime % 60);
   const timeLeft = `${minutes}:${seconds.toString().padStart(2, '0')}`;
+
   const handleSkip = useCallback(() => {
     const from = location.state?.from;
     if (from === ROUTE_PATH.SETTINGS) {
@@ -78,5 +87,6 @@ export const useAlarmSetup = () => {
       navigate(ROUTE_PATH.MY_TASK);
     }
   }, [navigate, location.state?.from]);
+
   return { qrData, isPending: isPending && !data, timeLeft, handleSkip };
 };

--- a/src/pages/AlarmSetupMobilePage.tsx
+++ b/src/pages/AlarmSetupMobilePage.tsx
@@ -19,6 +19,7 @@ import IOSGuide from '@/features/webpush/components/IOSGuide';
 const AlarmSetupMobilePage = () => {
   const [params] = useSearchParams();
   const qrToken = params.get('token');
+
   const { mutate: connectPushSession } = useConnectPushSessionMutation();
   const { registerPushSubscription, isLoading } = useAlarmPermission(qrToken);
 
@@ -26,6 +27,7 @@ const AlarmSetupMobilePage = () => {
 
   const triedConnectRef = useRef(false);
   const hasShownError = useRef(false);
+
   const isQrValid = Boolean(qrToken);
   const isWebPushSupported = supportsWebPush();
   const isIOSNotStandalone = getIsIOS() && !getIsStandalone();
@@ -78,6 +80,7 @@ const AlarmSetupMobilePage = () => {
 
   return (
     <StatusView
+      key={permission}
       icon={status.icon}
       title={status.title}
       message={status.message}
@@ -92,7 +95,8 @@ const AlarmSetupMobilePage = () => {
           <Button
             onClick={handleAllow}
             disabled={isAllowDisabled}
-            className="w-full py-6 bg-boost-blue hover:bg-boost-blue-hover active:bg-boost-blue-pressed text-gray-100 title2-bold duration-300 shadow-md cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+            variant="defaultBoost"
+            className="w-full py-6 active:bg-boost-blue-pressed !title2-regular disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <CheckCircle className="w-4 h-4" />
             {isLoading ? '처리 중...' : '허용'}


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약

- 모바일에서 이전 프레임의 블러 효과, 카드 shadow 등의 요소가 어긋나보이는 잔상 렌더링 이슈를 수정했습니다.


<br/>

### ✨ 작업 내용

- permission 상태를 key로 활용하여 StatusView 리마운트를 강제하여 해결했습니다.

<br/>

### ❗ 참고 사항(선택)

- QA에서 테스트가 필요할 듯 합니다!

<br/>

### #️⃣ 연관 이슈

- Close #519