### PR TITLE
♻️ (#521) QA 진행하면서 발견한 UI 개선 사항 및 버그 수정 작업

### DIFF
--- a/src/features/auth/components/KakaoLoginButton.tsx
+++ b/src/features/auth/components/KakaoLoginButton.tsx
@@ -6,7 +6,7 @@ const KakaoLoginButton = ({ onClick }: KakaoLoginButtonProps) => {
   return (
     <button
       onClick={onClick}
-      className="w-full bg-[#FEE500] hover:bg-[#FDD835] text-black/85 font-bold py-3 sm:py-4 px-6 rounded-[12px] flex items-center justify-center gap-3 transition-all duration-300 shadow-lg hover:shadow-xl hover:-translate-y-1 active:translate-y-0"
+      className="w-full bg-[#FEE500] hover:bg-[#FDD835] text-black/85 font-bold py-3 sm:py-4 px-6 rounded-[12px] flex items-center justify-center gap-3 transition-all duration-300 shadow-lg hover:shadow-xl hover:-translate-y-1 active:translate-y-0 cursor-pointer"
     >
       <svg className="w-6 h-6" viewBox="0 0 24 24" fill="none">
         <path

--- a/src/features/file/components/FileTableEmpty.tsx
+++ b/src/features/file/components/FileTableEmpty.tsx
@@ -2,7 +2,7 @@ import { TableRow, TableCell } from '@/shared/components/shadcn/table';
 
 const FileTableEmpty = () => {
   return (
-    <TableRow>
+    <TableRow className="hover:bg-transparent">
       <TableCell colSpan={6}>
         <div className="flex flex-col items-center justify-center text-gray-400 h-64">
           <div className="text-4xl mb-2">📄</div>

--- a/src/features/memo/components/MemoList/MemoTable.tsx
+++ b/src/features/memo/components/MemoList/MemoTable.tsx
@@ -73,7 +73,7 @@ const MemoTable = ({
               />
             ))
           ) : (
-            <TableRow>
+            <TableRow className="hover:bg-transparent">
               <TableCell colSpan={6}>
                 <div className="flex flex-col items-center justify-center text-gray-400 h-64">
                   <div className="text-4xl mb-2">📄</div>

--- a/src/features/search/components/TagSearchInput.tsx
+++ b/src/features/search/components/TagSearchInput.tsx
@@ -125,10 +125,10 @@ const TagSearchInput = () => {
                   className="data-[state=checked]:border-boost-blue data-[state=checked]:bg-boost-blue"
                 />
                 <Badge
-                  className="max-w-34 whitespace-normal break-words px-3 py-1 shadow-sm sm:max-w-72"
+                  className="whitespace-normal break-words px-3 py-1 shadow-sm max-w-30 sm:max-w-40 md:max-w-50 lg:max-w-60"
                   style={tagStyle}
                 >
-                  {tag.name}
+                  <span className="truncate">{tag.name}</span>
                 </Badge>
               </div>
             );

--- a/src/features/settings/components/UserInfoCard.tsx
+++ b/src/features/settings/components/UserInfoCard.tsx
@@ -53,7 +53,7 @@ export const UserInfoCard = ({ member }: UserInfoComponentProps) => {
       <Input
         value={newName}
         onChange={(e) => setNewName(e.target.value)}
-        className="w-40 !body2-regular sm:!body1-regular"
+        className="w-40 !body2-regular sm:!body1-regular focus:ring-transparent focus:border-gray-400"
       />
       <Button size="sm" variant="defaultBoost" onClick={handleNameSave} disabled={isPending}>
         {isPending ? '저장 중...' : '저장'}

--- a/src/features/tag/components/TagChip.tsx
+++ b/src/features/tag/components/TagChip.tsx
@@ -14,10 +14,10 @@ const TagChip = ({ tag, onRemove }: TagChipProps) => {
   return (
     <Badge
       key={tag.tagId}
-      className="cursor-default py-1 gap-1.5 shadow-sm transition-all duration-200 animate-in fade-in slide-in-from-left-2"
+      className="cursor-default py-1 gap-1.5 shadow-sm transition-all duration-200 animate-in fade-in slide-in-from-left-2 max-w-40"
       style={TagStyle}
     >
-      {tag.name}
+      <span className="truncate">{tag.name}</span>
       <Button
         size="icon"
         variant="ghost"

--- a/src/features/tag/components/TagInput/TagDropdownItem.tsx
+++ b/src/features/tag/components/TagInput/TagDropdownItem.tsx
@@ -92,8 +92,11 @@ const TagDropdownItem = ({
         >
           {isSelected && <Check className="w-3.5 h-3.5 text-white" />}
         </div>
-        <Badge className="px-3 py-1 shadow-sm" style={TagStyle}>
-          {tag.name}
+        <Badge
+          className="px-3 py-1 shadow-sm max-w-30 sm:max-w-65 md:max-w-75 lg:max-w-100"
+          style={TagStyle}
+        >
+          <span className="truncate">{tag.name}</span>
         </Badge>
       </div>
 

--- a/src/features/tag/components/TagInput/TagInput.tsx
+++ b/src/features/tag/components/TagInput/TagInput.tsx
@@ -112,7 +112,7 @@ const TagInput = ({
           onKeyDown={handleKeyDown}
           placeholder={tags.length === 0 ? '태그 입력 후 Enter' : ''}
           disabled={disabled}
-          className="flex-1 min-w-[120px] h-8 border-none focus:ring-transparent label2-regular bg-transparent placeholder:text-gray-400"
+          className="flex-1 min-w-[120px] h-8 border-none focus:ring-transparent !label1-regular bg-transparent placeholder:text-gray-400"
         />
       </div>
 

--- a/src/features/task-detail/components/TaskDetailContent/AssigneeMoreList.tsx
+++ b/src/features/task-detail/components/TaskDetailContent/AssigneeMoreList.tsx
@@ -4,6 +4,7 @@ import { User, ChevronLeft, ChevronRight } from 'lucide-react';
 import ContentItem from '@/shared/components/ui/ContentItem';
 import { getAvatarSrc } from '@/features/avatar-picker/utils/avatarUtils';
 import { MAX_DISPLAY_ASSIGNEES } from '@/features/task-detail/constants/task-detail.ui.constants';
+import { Button } from '@/shared/components/shadcn/button';
 
 interface AssigneeMoreListProps {
   assignees: { id: string; name: string; avatar?: string; backgroundColor?: string }[];
@@ -16,7 +17,7 @@ const AssigneeMoreList = ({ assignees }: AssigneeMoreListProps) => {
 
   return (
     <ContentItem icon={User} title="담당자">
-      <div className="flex flex-wrap gap-2.5">
+      <div className="flex flex-wrap gap-2.5 items-center">
         {displayedAssignees.map((assignee) => (
           <div
             key={assignee.id}
@@ -43,21 +44,22 @@ const AssigneeMoreList = ({ assignees }: AssigneeMoreListProps) => {
         ))}
 
         {hasMore && (
-          <button
+          <Button
             onClick={() => setShowAll(!showAll)}
-            className="flex items-center gap-1 px-3 py-1.5 rounded-lg bg-gray-50 hover:bg-gray-100 transition-colors body2-regular text-gray-600 border border-gray-200"
+            variant="outline"
+            className="gap-1 px-2 py-1 rounded-full !label2-bold bg-boost-blue/5 hover:bg-boost-blue/10 text-boost-blue-dark/70 hover:text-boost-blue-dark/80 border-boost-blue-dark/10 shadow-sm"
           >
             {showAll ? (
               <>
-                접기 <ChevronLeft className="w-3.5 h-3.5" />
+                접기 <ChevronLeft className="w-2.5 h-2.5" />
               </>
             ) : (
               <>
-                +{assignees.length - MAX_DISPLAY_ASSIGNEES}명{' '}
-                <ChevronRight className="w-3.5 h-3.5" />
+                + {assignees.length - MAX_DISPLAY_ASSIGNEES}명{' '}
+                <ChevronRight className="w-2.5 h-2.5" />
               </>
             )}
-          </button>
+          </Button>
         )}
       </div>
     </ContentItem>

--- a/src/features/task-detail/constants/task-detail.ui.constants.ts
+++ b/src/features/task-detail/constants/task-detail.ui.constants.ts
@@ -1,2 +1,2 @@
 export const PAGE_HORIZONTAL_PADDING = 16;
-export const MAX_DISPLAY_ASSIGNEES = 1;
+export const MAX_DISPLAY_ASSIGNEES = 3;

--- a/src/features/task/components/TaskModal/TaskFormField.tsx
+++ b/src/features/task/components/TaskModal/TaskFormField.tsx
@@ -61,7 +61,7 @@ const TaskFormField = ({
   const assignees = watch('assignees') || [];
 
   return (
-    <div className="flex flex-col gap-8 py-4 max-h-[400px] overflow-y-auto px-1">
+    <div className="flex flex-col gap-8 py-4 max-h-[400px] overflow-y-auto overflow-x-hidden px-1">
       {isMyTask && (
         <FormField icon={Folder} required label="프로젝트" error={errors.projectId?.message}>
           <ProjectSelect


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약

- QA를 진행하면서 발견한 UI 개선 및 버그 수정 작업 진행했습니다

<br/>

### ✨ 작업 내용

- 할 일 상세 정보에서 보여주는 담당자 목록이 현재 1로 지정되어있는 max 값에 따라 1명만 보여주고, 나머지는 더보기 버튼으로 보여주고 있습니다. 이를 3으로 조정하여 3명까지는 기본적으로 보여주도록 수정했습니다.
- 할 일 상세 정보 담당자 목록의 더보기 버튼의 디자인을 개선했습니다.
   <img width="577" height="352" alt="스크린샷 2026-04-04 205046" src="https://github.com/user-attachments/assets/5692bc92-afd0-439c-a96a-5dc07082e7cb" />
- 카카오 로그인 버튼에 cursor pointer 효과를 추가했습니다.
- 메모와 파일 목록이 비었을 때 나오는 UI에서, 해당 Empty UI도 table의 row로 구현되어있어 기본 hover 효과가 들어있습니다. 높이가 64로 지정되어 있어 hover 했을 때 row 영역만큼 그레이 빛이 돌아 UI가 깨지는 느낌이 있어, 해당 Empty Row에는 배경색 hover 효과를 transparent로 처리하도록 했습니다.
- 태그 길이가 길어지면 UI가 망가지고 있어 화면 너비에 따른 태그 최대 길이 조정 + truncate 처리 + 가로스크롤 hidden 추가해줬습니다.
- 설정 페이지에서 이름 수정할 때 나오는 Input을 다른 컴포넌트와 동일하게 ring 효과를 개선해줬습니다.

<br/> 

### ❗ 참고 사항(선택)

- 현재 둘러보면서 발견된 사항만 작업했고, 추가로 발견 시 지속해서 업데이트할 예정입니다.

<br/>

### #️⃣ 연관 이슈

- Close #521
