### PR TITLE
🚸 (#113) 할 일 생성/수정 모달 유효성 검사 UX 개선

### DIFF
--- a/src/features/task/components/TaskModal/TaskFormField.tsx
+++ b/src/features/task/components/TaskModal/TaskFormField.tsx
@@ -61,7 +61,7 @@ const TaskFormField = ({
   const assignees = watch('assignees') || [];
 
   return (
-    <div className="flex flex-col gap-8 py-4 max-h-[400px] overflow-y-auto px-1">
+    <div className="flex flex-col gap-8 py-4 max-h-[400px] overflow-y-auto px-1 scroll-smooth">
       {isMyTask && (
         <FormField icon={Folder} required label="프로젝트" error={errors.projectId?.message}>
           <ProjectSelect

--- a/src/features/task/hooks/form/useCreateTaskForm.ts
+++ b/src/features/task/hooks/form/useCreateTaskForm.ts
@@ -68,25 +68,36 @@ export const useCreateTaskForm = (
     }
   }, [numAssignees, maxReviewers, form]);
 
-  const handleConfirm = form.handleSubmit(async (data) => {
-    setIsLoading(true);
-    try {
-      const assigneeIds = data.assignees
-        .map((name) => projectMembers.find((m) => m.name === name || m.id === name)?.id)
-        .filter((id): id is string => !!id);
+  const handleConfirm = form.handleSubmit(
+    async (data) => {
+      setIsLoading(true);
+      try {
+        const assigneeIds = data.assignees
+          .map((name) => projectMembers.find((m) => m.name === name || m.id === name)?.id)
+          .filter((id): id is string => !!id);
 
-      const payload: CreateTaskInput = {
-        ...data,
-        assignees: assigneeIds,
-      };
+        const payload: CreateTaskInput = {
+          ...data,
+          assignees: assigneeIds,
+        };
 
-      await onConfirm(payload);
-      resetModal();
-      form.reset();
-    } finally {
-      setIsLoading(false);
-    }
-  });
+        await onConfirm(payload);
+        resetModal();
+        form.reset();
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    (errors) => {
+      const firstErrorKey = Object.keys(errors)[0];
+
+      const el = document.querySelector(`[name="${firstErrorKey}"]`);
+      if (el instanceof HTMLElement) {
+        el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        el.focus();
+      }
+    },
+  );
 
   return { form, handleConfirm, isLoading };
 };

--- a/src/features/task/hooks/form/useUpdateTaskForm.ts
+++ b/src/features/task/hooks/form/useUpdateTaskForm.ts
@@ -61,25 +61,36 @@ export const useUpdateTaskForm = (
     }
   }, [numAssignees, maxReviewers, form]);
 
-  const handleConfirm = form.handleSubmit(async (data) => {
-    setIsLoading(true);
-    try {
-      const assigneeIds: string[] = data.assignees
-        .map((name) => projectMembers.find((m) => m.name === name)?.id)
-        .filter((id): id is string => !!id);
+  const handleConfirm = form.handleSubmit(
+    async (data) => {
+      setIsLoading(true);
+      try {
+        const assigneeIds: string[] = data.assignees
+          .map((name) => projectMembers.find((m) => m.name === name)?.id)
+          .filter((id): id is string => !!id);
 
-      const payload: UpdateTaskInput = {
-        ...data,
-        assignees: assigneeIds,
-      };
+        const payload: UpdateTaskInput = {
+          ...data,
+          assignees: assigneeIds,
+        };
 
-      await onConfirm(payload);
-      form.reset(data);
-      resetModal();
-    } finally {
-      setIsLoading(false);
-    }
-  });
+        await onConfirm(payload);
+        form.reset(data);
+        resetModal();
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    (errors) => {
+      const firstErrorKey = Object.keys(errors)[0];
+
+      const el = document.querySelector(`[name="${firstErrorKey}"]`);
+      if (el instanceof HTMLElement) {
+        el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        el.focus();
+      }
+    },
+  );
 
   return { form, handleConfirm, isLoading };
 };


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약

- 할 일 생성/수정 모달 유효성 검사 UX를 개선했습니다.

<br/>

### ✨ 작업 내용

- 버튼 disabled 처리 대신, 입력하지 하는 폼으로 이동시켜주는 기능을 추가했습니다.
- 흐름은 아래 영상을 확인해주세요

<br/>

https://github.com/user-attachments/assets/aa606252-9fb5-45b5-b376-c99a92ca727a


<br/><br/>


### ❗ 참고 사항(선택)

- X

<br/>

### #️⃣ 연관 이슈

- Close #113 
