### PR TITLE
♻️ (#526) 설정 페이지 UI 개선 + 코드 리팩터링 + 라이선스 표기 상세화

### DIFF
--- a/src/features/settings/components/AlarmSettingCard.tsx
+++ b/src/features/settings/components/AlarmSettingCard.tsx
@@ -1,15 +1,16 @@
 import { useEffect, useState } from 'react';
-import { Switch } from '@/shared/components/shadcn/switch';
-import { SettingsSectionCard } from '@/features/settings/components/SettingsSectionCard';
-import { Card } from '@/shared/components/shadcn/card';
+import { useNavigate } from 'react-router-dom';
+import { PlusCircle } from 'lucide-react';
+import { ROUTE_PATH } from '@/app/routes/routePaths';
 import { cn } from '@/shared/lib/utils';
+import { Switch } from '@/shared/components/shadcn/switch';
+import { Card } from '@/shared/components/shadcn/card';
+import { Button } from '@/shared/components/shadcn/button';
+import { SettingsSectionCard } from '@/features/settings/components/SettingsSectionCard';
 import { useProjectsQuery } from '@/features/project/hooks/query/useProjectsQuery';
 import { useUpdateNotificationSettingsMutation } from '@/features/settings/hooks/useUpdateNotificationSettingsMutation';
 import { useUpdateProjectNotificationSettingsMutation } from '@/features/settings/hooks/useUpdateProjectNotificationSettingsMutation';
 import { useMyInfoQuery } from '@/features/settings/hooks/useMyInfoQuery';
-import { Button } from '@/shared/components/shadcn/button';
-import { useNavigate } from 'react-router-dom';
-import { ROUTE_PATH } from '@/app/routes/routePaths';
 
 const AlarmSettingCard = () => {
   const [isServiceAlarmOn, setIsServiceAlarmOn] = useState(true);
@@ -55,16 +56,19 @@ const AlarmSettingCard = () => {
   return (
     <SettingsSectionCard
       title="웹푸시 알림 설정"
-      desc="서비스 알림과 프로젝트별 알림을 관리할 수 있습니다 🔔"
+      desc="서비스 알림과 프로젝트별 알림을 관리할 수 있습니다."
     >
       {/* 기기 등록 버튼 */}
       <div className="px-1 mb-4 sm:mb-7">
         <Button
           variant="defaultBoost"
-          className="!label2-regular sm:!label1-regular"
+          className="w-full md:w-auto"
           onClick={() => navigate(ROUTE_PATH.ALARM_SETUP, { state: { from: ROUTE_PATH.SETTINGS } })}
         >
-          새로운 기기 등록하기
+          <PlusCircle />
+          <span className="label2-regular sm:label1-regular">
+            새로운 기기 등록<span className="inline md:hidden">하기</span>
+          </span>
         </Button>
       </div>
 
@@ -73,12 +77,16 @@ const AlarmSettingCard = () => {
         <Card className="p-4 bg-gray-50 border-gray-200">
           <div className="flex items-center justify-between">
             <div className="flex flex-col gap-1">
-              <span className="body2-regular sm:body1-regular ">서비스 알림</span>
+              <span className="label1-bold">서비스 알림</span>
               <span className="label2-regular text-gray-500">
                 모든 프로젝트 알림을 한번에 제어합니다
               </span>
             </div>
-            <Switch checked={isServiceAlarmOn} onCheckedChange={handleServiceToggle} />
+            <Switch
+              checked={isServiceAlarmOn}
+              onCheckedChange={handleServiceToggle}
+              className="data-[state=checked]:bg-boost-blue"
+            />
           </div>
         </Card>
 
@@ -89,7 +97,7 @@ const AlarmSettingCard = () => {
             !isServiceAlarmOn && 'opacity-60 pointer-events-none',
           )}
         >
-          <p className="body2-regular sm:body1-regular px-1">프로젝트별 알림</p>
+          <p className="label1-bold pl-1">프로젝트별 알림</p>
 
           {projectsData && projectsData.length === 0 && (
             <div className="flex items-center justify-center py-8 text-gray-500 body2-regular">
@@ -102,7 +110,7 @@ const AlarmSettingCard = () => {
             return (
               <div
                 key={project.id}
-                className="flex items-center justify-between px-3 py-2 sm:px-4 sm:py-3"
+                className="flex items-center justify-between pl-3 py-2 sm:pl-4 sm:py-3"
               >
                 <span
                   className={cn(
@@ -116,6 +124,7 @@ const AlarmSettingCard = () => {
                   checked={enabled}
                   onCheckedChange={(val) => handleProjectToggle(project.id, val)}
                   disabled={!isServiceAlarmOn}
+                  className="data-[state=checked]:bg-boost-blue"
                 />
               </div>
             );

--- a/src/features/settings/components/DeleteAccountCard.tsx
+++ b/src/features/settings/components/DeleteAccountCard.tsx
@@ -1,6 +1,7 @@
+import { UserX } from 'lucide-react';
+import { useModal } from '@/shared/hooks/useModal';
 import { Button } from '@/shared/components/shadcn/button';
 import { SettingsSectionCard } from '@/features/settings/components/SettingsSectionCard';
-import { useModal } from '@/shared/hooks/useModal';
 import DeleteAccountModalContent from '@/features/settings/components/DeleteAccountModalContent';
 
 export const DeleteAccountCard = () => {
@@ -17,11 +18,14 @@ export const DeleteAccountCard = () => {
 
   return (
     <SettingsSectionCard
-      title="회원탈퇴"
+      title="회원 탈퇴"
       desc="탈퇴 시 모든 데이터가 삭제되며, 복구할 수 없습니다."
     >
-      <Button variant="destructive" onClick={showModal}>
-        회원탈퇴
+      <Button variant="destructive" onClick={showModal} className="w-full md:w-auto">
+        <UserX />
+        <span className="label2-regular sm:label1-regular">
+          회원 탈퇴<span className="inline md:hidden">하기</span>
+        </span>
       </Button>
     </SettingsSectionCard>
   );

--- a/src/features/settings/components/LicenseCard.tsx
+++ b/src/features/settings/components/LicenseCard.tsx
@@ -1,12 +1,34 @@
 import { SettingsSectionCard } from '@/features/settings/components/SettingsSectionCard';
+import { EXTERNAL_LINKS } from '@/shared/constants/external-links';
 
 export const LicenseCard = () => (
-  <SettingsSectionCard title="라이선스" desc="본 서비스는 다음 오픈소스 라이선스를 포함합니다.">
+  <SettingsSectionCard
+    title="저작권 및 라이선스"
+    desc="서비스에 사용된 이미지 및 리소스의 출처와 라이선스를 확인할 수 있습니다."
+  >
     <small>
-      Avatars by Stefanie – Licensed under
+      Avatars from{' '}
       <a
         className="text-blue-400"
-        href="https://creativecommons.org/licenses/by/4.0/"
+        href={EXTERNAL_LINKS.AVATAR_SOURCE_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        3D Funky Avatar Illustrations
+      </a>{' '}
+      by{' '}
+      <a
+        className="text-blue-400"
+        href={EXTERNAL_LINKS.AVATAR_AUTHOR_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Stefanie
+      </a>
+      , licensed under{' '}
+      <a
+        className="text-blue-400"
+        href={EXTERNAL_LINKS.CC_BY_4_LICENSE_URL}
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/src/features/settings/components/SettingsSectionCard.tsx
+++ b/src/features/settings/components/SettingsSectionCard.tsx
@@ -9,7 +9,7 @@ interface SettingsSectionCardProps {
 
 export const SettingsSectionCard = ({ title, desc, children }: SettingsSectionCardProps) => {
   return (
-    <Card className="shadow-none border-none mb-0 py-5 sm:py-6">
+    <Card className="border-none py-5 sm:py-6 shadow-sm">
       <CardHeader>
         <CardTitle className="title2-bold">{title}</CardTitle>
         {desc && (

--- a/src/features/settings/components/UserInfoCard.tsx
+++ b/src/features/settings/components/UserInfoCard.tsx
@@ -72,10 +72,10 @@ export const UserInfoCard = ({ member }: UserInfoComponentProps) => {
         <div className="flex flex-col md:flex-row items-center gap-4">
           <Avatar
             style={{ backgroundColor: member.backgroundColor }}
-            className="flex items-center justify-center w-20 h-20 md:w-18 md:h-18"
+            className="flex items-center justify-center w-24 h-24 md:w-18 md:h-18 shadow-sm"
           >
             <AvatarImage
-              className="object-contain w-16 h-16 md:w-15 md:h-15"
+              className="object-contain w-18 h-18 md:w-15 md:h-15"
               src={getAvatarSrc(member)}
               alt="user avatar"
             />

--- a/src/features/settings/components/UserInfoCard.tsx
+++ b/src/features/settings/components/UserInfoCard.tsx
@@ -53,7 +53,7 @@ export const UserInfoCard = ({ member }: UserInfoComponentProps) => {
       <Input
         value={newName}
         onChange={(e) => setNewName(e.target.value)}
-        className="w-40 !body2-regular sm:!body1-regular"
+        className="w-40 !body1-regular"
       />
       <Button size="sm" variant="defaultBoost" onClick={handleNameSave} disabled={isPending}>
         {isPending ? '저장 중...' : '저장'}
@@ -63,76 +63,45 @@ export const UserInfoCard = ({ member }: UserInfoComponentProps) => {
       </Button>
     </div>
   ) : (
-    <p className="body2-regular sm:body1-regular">{member.name}</p>
+    <p className="body1-regular">{member.name}</p>
   );
 
   return (
-    <SettingsSectionCard title="내 정보" desc="아바타와 이름을 변경할 수 있어요.">
-      <div className="hidden sm:flex items-center justify-between gap-6">
-        <div className="flex items-center gap-4">
+    <SettingsSectionCard title="내 정보" desc="아바타와 이름을 변경할 수 있습니다.">
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-6 px-3 py-4 md:px-0 md:py-0">
+        <div className="flex flex-col md:flex-row items-center gap-4">
           <Avatar
             style={{ backgroundColor: member.backgroundColor }}
-            className="w-18 h-18 flex items-center justify-center"
+            className="flex items-center justify-center w-20 h-20 md:w-18 md:h-18"
           >
             <AvatarImage
-              className="w-15 h-15 object-contain"
+              className="object-contain w-16 h-16 md:w-15 md:h-15"
               src={getAvatarSrc(member)}
               alt="user avatar"
             />
             <AvatarFallback>{member.name.charAt(0)}</AvatarFallback>
           </Avatar>
 
-          {NameArea}
+          <div className="min-h-[40px] flex items-center justify-center md:justify-start">
+            {NameArea}
+          </div>
         </div>
 
-        <div className="flex gap-3">
-          <Button variant="defaultBoost" onClick={openDrawer} className="w-40">
+        <div className="flex w-full md:w-auto gap-3">
+          <Button variant="defaultBoost" onClick={openDrawer} className="flex-1 md:w-40">
             <Pencil className="w-4 h-4" />
-            아바타 변경
+            <span className="label2-regular sm:label1-regular">아바타 변경</span>
           </Button>
+
           <Button
             variant="defaultBoost"
             onClick={() => setIsNameEditing(true)}
             disabled={isNameEditing}
-            className="w-40"
+            className="flex-1 md:w-40"
           >
             <Pencil className="w-4 h-4" />
-            이름 변경
+            <span className="label2-regular sm:label1-regular">이름 변경</span>
           </Button>
-        </div>
-      </div>
-
-      <div className="sm:hidden">
-        <div className="flex flex-col items-center gap-4 px-3 py-4 bg-gray-200 rounded-lg shadow-sm">
-          <Avatar
-            style={{ backgroundColor: member.backgroundColor }}
-            className="w-20 h-20 flex items-center justify-center"
-          >
-            <AvatarImage
-              className="w-16 h-16 object-contain"
-              src={getAvatarSrc(member)}
-              alt="user avatar"
-            />
-            <AvatarFallback className="text-xl">{member.name.charAt(0)}</AvatarFallback>
-          </Avatar>
-
-          <div className="w-full flex justify-center min-h-[40px]">{NameArea}</div>
-
-          <div className="flex w-full gap-3">
-            <Button variant="defaultBoost" onClick={openDrawer} className="flex-1">
-              <Pencil className="w-4 h-4" />
-              아바타 변경
-            </Button>
-            <Button
-              variant="defaultBoost"
-              onClick={() => setIsNameEditing(true)}
-              disabled={isNameEditing}
-              className="flex-1"
-            >
-              <Pencil className="w-4 h-4" />
-              이름 변경
-            </Button>
-          </div>
         </div>
       </div>
     </SettingsSectionCard>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -13,15 +13,15 @@ export default function SettingsPage() {
   if (isLoading || !myInfo) return <FullPageLoader text="정보 불러오는 중.." />;
 
   return (
-    <div className="overflow-y-auto">
-      <div className="flex flex-col px-2 sm:px-10 space-y-4 pt-4 pb-6">
+    <div className="overflow-y-auto bg-gray-200">
+      <div className="flex flex-col p-4 md:p-5 space-y-4">
         <UserInfoCard member={myInfo} />
         <AvatarsDrawer showEditButton={false} showSaveButton={true} />
-        <Separator />
+        <Separator className="bg-gray-300" />
         <AlarmSettingCard />
-        <Separator />
+        <Separator className="bg-gray-300" />
         <DeleteAccountCard />
-        <Separator />
+        <Separator className="bg-gray-300" />
         <LicenseCard />
       </div>
     </div>

--- a/src/shared/constants/external-links.ts
+++ b/src/shared/constants/external-links.ts
@@ -1,7 +1,14 @@
 export const EXTERNAL_LINKS = {
   GITHUB: 'https://github.com/ktc-boost',
+
   KAKAO_CHAT: 'http://pf.kakao.com/_KBAEX/chat',
   NAVER_FORM: 'https://naver.me/G9pDvPJh',
+
   TERMS: 'https://flat-capricorn-b40.notion.site/BOOST-2a3b32e74312805da68febc9a138d6b7',
   PRIVACY: 'https://flat-capricorn-b40.notion.site/BOOST-2a3b32e74312809da69de2046a8f38b3',
+
+  AVATAR_AUTHOR_URL:
+    'https://www.figma.com/files/team/1490970015852524182/resources/community/@stefanies?fuid=1490970011361990480',
+  AVATAR_SOURCE_URL: 'https://www.figma.com/community/file/1522556138728435368',
+  CC_BY_4_LICENSE_URL: 'https://creativecommons.org/licenses/by/4.0/',
 } as const;


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약

- 설정 페이지 디자인 일부 개선했습니다.
- 설정 페이지 코드 일부 리팩터링 진행했습니다.
- 라이선스 표기를 상세화 했습니다.

<br/>

### ✨ 작업 내용

#### 1. 저작권 및 라이선스 표기 상세화
- 기존 **Avatars by Stefanie – Licensed under[CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)** 도 부족하진 않지만, 라이선스 링크 연동만이 아닌 해당 아바타의 정확한 source 명칭 사용, author와 source 링크도 연동을 하는 것이 좋을 것 같아 작업 진행했습니다.
- 이 작업에서 외부 링크들은 따로 `external-links` 파일에 상수로 분리하여 사용해주었습니다.
<img width="1801" height="204" alt="image" src="https://github.com/user-attachments/assets/cd66a017-da65-460e-b85a-b46cc32fc4f9" />

<br/><br/>

#### 2. 설정 페이지, 설정 페이지 공통 카드 컴포넌트 디자인 개선
- 설정 페이지  `padding 조절` + `구분선 색상 약간 흐릿하게` + `배경색 gray-200` 해주었습니다.
- 설정 페이지에서 섹션마다 공통으로 사용하는 카드 컴포넌트 디자인도 살짝 수정했습니다.
- 기존 그림자 없이 배경색과 같은 색상으로 평면적으로 보이는 UI를 Card UI를 살려서 페이지 배경색은 gray-200, 카드 컴포넌트는 그림자를 추가해주어 섹션의 구분감을 더해주었습니다.
- 카드로 구분감이 생겼으니 구분선은 살짝 연하게 처리해주었습니다.
- 카드 내 padding으로 페이지 상하좌우와 어느정도 구분이 이미 있으므로 페이지 전체의 padding은 조금 줄여주었습니다.
- UI 확인을 위한 이미지는 하단에 첨부해두었습니다.

<br/><br/>

#### 3. 사용자 정보 섹션 코드 리팩터링
- 기존에 sm:hidden 구조로 유사한 형태의 구조가 중복적으로 정의되어 있었습니다.
- 같은 기능, 같은 구조를 가지지만 사이즈, col/row 형태, 버튼의 너비 정도 다르므로 반응형 클래스를 사용하여 리팩터링 해주었습니다.
- UI는 기존과 동일하되, 모바일일 때 아바타 사이즈를 조금 더 크게 해주었습니다.
- ~요 체로 끝나던 섹션 description을 다른 섹션 멘트 형식과 통일했습니다.
- 세부적으로는 반응형 폰트 크기 정도 변경되었습니다.
- 하단 이미지로 확인 부탁드립니다.

<br/>

####  4. 알림 설정 섹션 UI 개선
- 스위치에 서비스 색상을 적용해주었습니다.
- 프로젝트별 알림 스위치는 서비스 알림 스위치와 동일선에 놓이도록 수정했습니다.
- 이모티콘으로 끝나던 섹션 description을 다른 섹션 멘트 형식과 통일했습니다.
- 새로운 기기 등록 버튼에 아이콘을 추가했습니다.
- 반응형 디자인을 조금 수정했습니다. 하단 이미지로 확인 부탁드립니다.

<br/>

#### 5. 회원 탈퇴 섹션 UI 개선
- 알림 설정 섹션 UI 개선 사항 중 반응형 디자인 수정에 따라, 회원 탈퇴도 유사한 방식으로 수정해주었습니다.
- 하단 이미지로 확인 부탁드립니다.


<br/>

#### 이미지 첨부

| 모바일-1 | 모바일-2 |
|---|---|
|  <img width="400" alt="image" src="https://github.com/user-attachments/assets/b948612f-f132-47f5-ba75-464ea75878f3" /> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/d8047cc4-1a0b-4915-9104-88040870d00f" /> |

| 데스크탑-1 | 데스크탑-2 |
|---|---|
|  <img width="400" alt="image" src="https://github.com/user-attachments/assets/19429de1-0c2b-4ce3-9d49-cf156e3c2e7f" /> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/d8fe3b0c-7cf5-4b1a-ad52-7f45fc729369" /> |

<br/><br/>

### ❗ 참고 사항(선택)

- 디자인은 취향의 영역이라 의견을 나눠보는 것이 맞을 것 같습니다!
- 이미지 확인 후 개선할 부분 피드백 남겨주시면 반영하겠습니다.

<br/>

### #️⃣ 연관 이슈

- Close #526 
