### PR TITLE
🔧 (#506) TypeScript baseUrl 제거 및 경로 설정 마이그레이션

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -22,9 +22,8 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src"]


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약

- deprecated된 `baseUrl`을 제거하고, `paths + bundler` 기반 구조로 전환하여 TS 7 대응 작업 진행했습니다.

<br/><br/>

### ✨ 작업 내용

- 갑자기 tsconfig.json 파일에 오류가 떠있어 확인해보니, TypeScript에서 `baseUrl` 옵션이 deprecated 되었으며, TypeScript 7.0부터는 더 이상 동작하지 않을 예정인 듯합니다.
- 자세한 내용은 #506 이슈를 확인해주세요.
- 기존 설정을 유지할 경우 향후 버전 업 시 빌드 오류가 발생할 수 있어, 공식 권장 방식으로 마이그레이션을 진행했습니다.
- `tsconfig.json` 파일에서 `baseUrl` 옵션을 제거하고 `paths`를 명시적 경로(`./src/*`) 기반으로 수정했습니다.
- 기존 import alias (`@/...`) 구조는 그대로 유지됩니다.
- `moduleResolution: "bundler"` 환경에서는 baseUrl 없이도 경로 해석 가능하다고 합니다!
- Vite의 `alias` 설정과 함께 사용하는 것이 최신 권장 방식이라고 합니다!


```diff
- "baseUrl": ".",
  "paths": {
-   "@/*": ["src/*"]
+   "@/*": ["./src/*"]
  }
```

<br/>

#### 🔗 참고 자료

- [TypeScript 공식 마이그레이션 안내](https://aka.ms/ts6)
- [TypeScript Handbook - Module Resolution](https://www.typescriptlang.org/docs/handbook/module-resolution.html)
- [Vite 공식 문서 - Resolve Alias](https://vitejs.dev/config/shared-options.html#resolve-alias)

<br/>

### ❗ 참고 사항(선택)

- X

<br/>

### #️⃣ 연관 이슈

- Close #506 
