### PR TITLE
🐛 (#529) 팀원 많아졌을 때 프로젝트 관리/정보 모달 UI 깨짐 문제 해결

### DIFF
--- a/src/features/project/components/ProjectMembersList.tsx
+++ b/src/features/project/components/ProjectMembersList.tsx
@@ -7,9 +7,9 @@ interface ProjectMembersListProps {
 
 const ProjectMembersList = ({ members }: ProjectMembersListProps) => {
   return (
-    <div className="flex-1.5 overflow-y-auto overflow-x-hidden md:border-r border-gray-300">
-      <div className="space-y-2 min-w-[220px] md:min-w-[260px] lg:min-w-[320px]">
-        <p className="md:hidden label1-bold pl-2">프로젝트 멤버</p>
+    <div className="flex-1.5 overflow-x-hidden md:border-r border-gray-300">
+      <p className="md:hidden label1-bold pl-2 pb-2">프로젝트 멤버</p>
+      <div className="space-y-2 min-w-[220px] md:min-w-[260px] lg:min-w-[320px] overflow-y-auto max-h-30 md:max-h-55">
         {members.map((member) => (
           <ProjectMemberItem key={member.id} member={member} />
         ))}


### PR DESCRIPTION
## PR

### 🔍 한 줄 요약

- 프로젝트 관리/정보 모달 UI 깨짐 문제를 해결했습니다.

<br/>

### ✨ 작업 내용

- 테스트 프로젝트로 확인해보니 팀원이 많아졌을 때 프로젝트 관리/정보 모달 UI가 깨지는 버그가 있어 이를 해결했습니다.
- 최대 높이를 지정해주어 일정 높이가 넘어섰을 땐 스크롤로 처리되도록 했습니다.

<br/>

#### 이미지 첨부

<img width="600" alt="image" src="https://github.com/user-attachments/assets/c4b6b4d1-66b6-423c-b3e9-9c34180bcbb8" />
<img width="600" alt="image" src="https://github.com/user-attachments/assets/9d711716-53eb-4391-bb9a-6fd63a00a6c0" />


<br/><br/>

### ❗ 참고 사항(선택)

- 리뷰어가 참고해야 할 부분이나 추가로 확인할 부분을 작성해주세요.

<br/>

### #️⃣ 연관 이슈

- Close #529 
